### PR TITLE
Restore JMX monitoring

### DIFF
--- a/spring-petclinic-config-server/pom.xml
+++ b/spring-petclinic-config-server/pom.xml
@@ -31,18 +31,6 @@
 
 	</dependencies>
 
-	<dependencyManagement>
-		<dependencies>
-			<dependency>
-				<groupId>org.springframework.cloud</groupId>
-				<artifactId>spring-cloud-dependencies</artifactId>
-				<version>Camden.SR1</version>
-				<type>pom</type>
-				<scope>import</scope>
-			</dependency>
-		</dependencies>
-	</dependencyManagement>
-
 	<build>
 		<plugins>
 			<plugin>

--- a/spring-petclinic-customers-service/src/main/java/org/springframework/samples/petclinic/customers/web/OwnerResource.java
+++ b/spring-petclinic-customers-service/src/main/java/org/springframework/samples/petclinic/customers/web/OwnerResource.java
@@ -25,6 +25,7 @@ import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.http.HttpStatus;
 import org.springframework.samples.petclinic.customers.model.Owner;
 import org.springframework.samples.petclinic.customers.model.OwnerRepository;
+import org.springframework.samples.petclinic.monitoring.Monitored;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
@@ -53,6 +54,7 @@ class OwnerResource {
      */
     @PostMapping
     @ResponseStatus(HttpStatus.CREATED)
+    @Monitored
     public void createOwner(@Valid @RequestBody Owner owner) {
         ownerRepository.save(owner);
     }
@@ -77,6 +79,7 @@ class OwnerResource {
      * Update Owner
      */
     @PutMapping(value = "/{ownerId}")
+    @Monitored
     public Owner updateOwner(@PathVariable("ownerId") int ownerId, @Valid @RequestBody Owner ownerRequest) {
         final Owner ownerModel = ownerRepository.findOne(ownerId);
         // This is done by hand for simplicity purpose. In a real life use-case we should consider using MapStruct.

--- a/spring-petclinic-customers-service/src/main/java/org/springframework/samples/petclinic/customers/web/PetResource.java
+++ b/spring-petclinic-customers-service/src/main/java/org/springframework/samples/petclinic/customers/web/PetResource.java
@@ -26,6 +26,7 @@ import org.springframework.samples.petclinic.customers.model.OwnerRepository;
 import org.springframework.samples.petclinic.customers.model.Pet;
 import org.springframework.samples.petclinic.customers.model.PetRepository;
 import org.springframework.samples.petclinic.customers.model.PetType;
+import org.springframework.samples.petclinic.monitoring.Monitored;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
@@ -55,6 +56,7 @@ class PetResource {
 
     @PostMapping("/owners/{ownerId}/pets")
     @ResponseStatus(HttpStatus.NO_CONTENT)
+    @Monitored
     public void processCreationForm(
         @RequestBody PetRequest petRequest,
         @PathVariable("ownerId") int ownerId) {
@@ -68,6 +70,7 @@ class PetResource {
 
     @PutMapping("/owners/*/pets/{petId}")
     @ResponseStatus(HttpStatus.NO_CONTENT)
+    @Monitored
     public void processUpdateForm(@RequestBody PetRequest petRequest) {
         save(petRepository.findOne(petRequest.getId()), petRequest);
     }

--- a/spring-petclinic-monitoring/pom.xml
+++ b/spring-petclinic-monitoring/pom.xml
@@ -10,24 +10,23 @@
     <packaging>jar</packaging>
     <description>Spring PetClinic monitoring utilities</description>
 
+    <parent>
+        <groupId>org.springframework.samples</groupId>
+        <artifactId>spring-petclinic-microservices</artifactId>
+        <version>1.4.2</version>
+    </parent>
+
     <dependencies>
+        <!-- Spring dependencies -->
+        <dependency>
+            <groupId>org.springframework</groupId>
+            <artifactId>spring-context</artifactId>
+        </dependency>
+
         <!-- Third-parties -->
         <dependency>
             <groupId>org.aspectj</groupId>
             <artifactId>aspectjweaver</artifactId>
-            <version>1.8.0</version>
-        </dependency>
-        <dependency>
-            <groupId>org.springframework</groupId>
-            <artifactId>spring-jmx</artifactId>
-            <scope>provided</scope>
-            <version>2.0.8</version>
-        </dependency>
-        <dependency>
-            <groupId>org.springframework</groupId>
-            <artifactId>spring-context</artifactId>
-            <scope>provided</scope>
-            <version>4.3.4.RELEASE</version>
         </dependency>
     </dependencies>
 </project>


### PR DESCRIPTION
Due to some refactoring, the @Monitored annotation was unused.
I've enable it on PetResource and CustomerResource.
CallMonitor MBean could be displayed into JVisualVM :
<img width="959" alt="mbean-petclinic" src="https://cloud.githubusercontent.com/assets/838318/21418504/f871da34-c821-11e6-973c-28a26636cd36.png">
