### PR TITLE
Zipkin server is unavailable when running services with Docker

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -23,6 +23,7 @@ services:
     links:
      - config-server
      - discovery-server
+     - tracing-server
     depends_on:
      - config-server
      - discovery-server
@@ -36,6 +37,7 @@ services:
     links:
      - config-server
      - discovery-server
+     - tracing-server
     depends_on:
      - config-server
      - discovery-server
@@ -49,6 +51,7 @@ services:
     links:
      - config-server
      - discovery-server
+     - tracing-server
     depends_on:
      - config-server
      - discovery-server
@@ -65,6 +68,7 @@ services:
      - customers-service
      - visits-service
      - vets-service
+     - tracing-server
     depends_on:
      - config-server
      - discovery-server


### PR DESCRIPTION
I've prepared a fix for issue that I came across while running services with Docker. Accompanying fix for the config has been already commited: https://github.com/spring-petclinic/spring-petclinic-microservices-config/commit/29118ee95e2dd2d1b295835a8e0655aaa754966d

@arey please review