### PR TITLE
Fixed SpringBootAdminApplication startup error

### DIFF
--- a/spring-petclinic-admin-server/pom.xml
+++ b/spring-petclinic-admin-server/pom.xml
@@ -16,7 +16,7 @@
     </parent>
 
     <properties>
-        <spring-boot-admin.version>1.5.1</spring-boot-admin.version>
+        <spring-boot-admin.version>1.5.6</spring-boot-admin.version>
     </properties>
 
     <dependencies>


### PR DESCRIPTION
`org.springframework.beans.factory.BeanDefinitionStoreException: Failed to process import candidates for configuration class [org.springframework.samples.petclinic.admin.SpringBootAdminApplication]; nested exception is java.lang.NoClassDefFoundError: org/springframework/cloud/netflix/zuul/ZuulConfiguration`

To fix this startup error the Spring Boot Admin version was updated to the current version 1.5.6.