### PR TITLE
Reduce memory consumption of Docker images #76

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,6 +27,9 @@ After starting services it takes a while for API Gateway to be in sync with serv
 so don't be scared of initial Zuul timeouts. You can track services availability using Eureka dashboard
 available by default at http://localhost:8761.
 
+*NOTE: Under MacOSX or Windows, make sure that the Docker VM has enough memory to run the microservices. The default settings
+are usually not enough and make the `docker-compose up` painfully slow.*
+
 ## Understanding the Spring Petclinic application with a few diagrams
 <a href="https://speakerdeck.com/michaelisvy/spring-petclinic-sample-application">See the presentation here</a>
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -3,23 +3,26 @@ services:
   config-server:
     image: mszarlinski/spring-petclinic-config-server
     container_name: config-server
+    mem_limit: 256M
     ports:
      - 8888:8888
 
   discovery-server:
     image: mszarlinski/spring-petclinic-discovery-server
     container_name: discovery-server
+    mem_limit: 256M
     links:
      - config-server
     depends_on:
       - config-server
-    entrypoint: ["./wait-for-it.sh","config-server:8888","--timeout=60","--","java","-Djava.security.egd=file:/dev/./urandom","-jar","/app.jar"]
+    entrypoint: ["./wait-for-it.sh","config-server:8888","--timeout=60","--","java", "-XX:+UnlockExperimentalVMOptions", "-XX:+UseCGroupMemoryLimitForHeap", "-Djava.security.egd=file:/dev/./urandom","-jar","/app.jar"]
     ports:
      - 8761:8761
 
   customers-service:
     image: mszarlinski/spring-petclinic-customers-service
     container_name: customers-service
+    mem_limit: 256M
     links:
      - config-server
      - discovery-server
@@ -27,13 +30,14 @@ services:
     depends_on:
      - config-server
      - discovery-server
-    entrypoint: ["./wait-for-it.sh","discovery-server:8761","--timeout=60","--","java","-Djava.security.egd=file:/dev/./urandom","-jar","/app.jar"]
+    entrypoint: ["./wait-for-it.sh","discovery-server:8761","--timeout=60","--","java", "-XX:+UnlockExperimentalVMOptions", "-XX:+UseCGroupMemoryLimitForHeap", "-Djava.security.egd=file:/dev/./urandom","-jar","/app.jar"]
     ports:
     - 8081:8081
 
   visits-service:
     image: mszarlinski/spring-petclinic-visits-service
     container_name: visits-service
+    mem_limit: 256M
     links:
      - config-server
      - discovery-server
@@ -41,13 +45,14 @@ services:
     depends_on:
      - config-server
      - discovery-server
-    entrypoint: ["./wait-for-it.sh","discovery-server:8761","--timeout=60","--","java","-Djava.security.egd=file:/dev/./urandom","-jar","/app.jar"]
+    entrypoint: ["./wait-for-it.sh","discovery-server:8761","--timeout=60","--","java", "-XX:+UnlockExperimentalVMOptions", "-XX:+UseCGroupMemoryLimitForHeap", "-Djava.security.egd=file:/dev/./urandom","-jar","/app.jar"]
     ports:
      - 8082:8082
 
   vets-service:
     image: mszarlinski/spring-petclinic-vets-service
     container_name: vets-service
+    mem_limit: 256M
     links:
      - config-server
      - discovery-server
@@ -55,13 +60,14 @@ services:
     depends_on:
      - config-server
      - discovery-server
-    entrypoint: ["./wait-for-it.sh","discovery-server:8761","--timeout=60","--","java","-Djava.security.egd=file:/dev/./urandom","-jar","/app.jar"]
+    entrypoint: ["./wait-for-it.sh","discovery-server:8761","--timeout=60","--","java", "-XX:+UnlockExperimentalVMOptions", "-XX:+UseCGroupMemoryLimitForHeap", "-Djava.security.egd=file:/dev/./urandom","-jar","/app.jar"]
     ports:
      - 8083:8083
 
   api-gateway:
     image: mszarlinski/spring-petclinic-api-gateway
     container_name: api-gateway
+    mem_limit: 256M
     links:
      - config-server
      - discovery-server
@@ -72,32 +78,34 @@ services:
     depends_on:
      - config-server
      - discovery-server
-    entrypoint: ["./wait-for-it.sh","discovery-server:8761","--timeout=60","--","java","-Djava.security.egd=file:/dev/./urandom","-jar","/app.jar"]
+    entrypoint: ["./wait-for-it.sh","discovery-server:8761","--timeout=60","--","java", "-XX:+UnlockExperimentalVMOptions", "-XX:+UseCGroupMemoryLimitForHeap", "-Djava.security.egd=file:/dev/./urandom","-jar","/app.jar"]
     ports:
      - 8080:8080
 
   tracing-server:
     image: mszarlinski/spring-petclinic-tracing-server
     container_name: tracing-server
+    mem_limit: 256M
     links:
      - config-server
      - discovery-server
     depends_on:
      - config-server
      - discovery-server
-    entrypoint: ["./wait-for-it.sh","discovery-server:8761","--timeout=60","--","java","-Djava.security.egd=file:/dev/./urandom","-jar","/app.jar"]
+    entrypoint: ["./wait-for-it.sh","discovery-server:8761","--timeout=60","--","java", "-XX:+UnlockExperimentalVMOptions", "-XX:+UseCGroupMemoryLimitForHeap", "-Djava.security.egd=file:/dev/./urandom","-jar","/app.jar"]
     ports:
      - 9411:9411
 
   admin-server:
     image: mszarlinski/spring-petclinic-admin-server
     container_name: admin-server
+    mem_limit: 256M
     links:
      - config-server
      - discovery-server
     depends_on:
      - config-server
      - discovery-server
-    entrypoint: ["./wait-for-it.sh","discovery-server:8761","--timeout=60","--","java","-Djava.security.egd=file:/dev/./urandom","-jar","/app.jar"]
+    entrypoint: ["./wait-for-it.sh","discovery-server:8761","--timeout=60","--","java", "-XX:+UnlockExperimentalVMOptions", "-XX:+UseCGroupMemoryLimitForHeap", "-Djava.security.egd=file:/dev/./urandom","-jar","/app.jar"]
     ports:
      - 9090:9090

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -1,4 +1,4 @@
-FROM java:8
+FROM openjdk:8
 VOLUME /tmp
 ADD https://raw.githubusercontent.com/vishnubob/wait-for-it/master/wait-for-it.sh wait-for-it.sh
 RUN bash -c 'chmod +x wait-for-it.sh'
@@ -7,4 +7,4 @@ ADD ${ARTIFACT_NAME}.jar /app.jar
 ENV SPRING_PROFILES_ACTIVE docker
 RUN bash -c 'touch /app.jar'
 EXPOSE ${EXPOSED_PORT}
-ENTRYPOINT ["java","-Djava.security.egd=file:/dev/./urandom","-jar","/app.jar"]
+ENTRYPOINT ["java", "-XX:+UnlockExperimentalVMOptions", "-XX:+UseCGroupMemoryLimitForHeap", "-Djava.security.egd=file:/dev/./urandom","-jar","/app.jar"]


### PR DESCRIPTION
The fix switches from an outdated Oracle Java 8 Docker image
to the current openjdk:8 image. The Java VM of this image
supports the parameters to make the Java VM Docker aware.
With this option it becomes possible to set the memory
limit to 256MB which reduces the memory consumption by
75% and leaves the application still operational.