### PR TITLE
Update to alpine and dockerize

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,7 +22,7 @@ You can tell Config Server to use your local Git repository by using `local` Spr
 ## Starting services locally with docker-compose
 In order to start entire infrastructure using Docker, you have to build images by executing `./mvnw clean install -PbuildDocker` 
 from a project root. Once images are ready, you can start them with a single command
-`docker-compose up`. Containers startup order is coordinated with [`wait-for-it.sh` script](https://github.com/vishnubob/wait-for-it). 
+`docker-compose up`. Containers startup order is coordinated with [`dockerize` script](https://github.com/jwilder/dockerize). 
 After starting services it takes a while for API Gateway to be in sync with service registry,
 so don't be scared of initial Zuul timeouts. You can track services availability using Eureka dashboard
 available by default at http://localhost:8761.

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -11,8 +11,6 @@ services:
     image: mszarlinski/spring-petclinic-discovery-server
     container_name: discovery-server
     mem_limit: 512M
-    links:
-     - config-server
     depends_on:
       - config-server
     entrypoint: ["./dockerize","-wait=tcp://config-server:8888","-timeout=60s","--","java", "-XX:+UnlockExperimentalVMOptions", "-XX:+UseCGroupMemoryLimitForHeap", "-Djava.security.egd=file:/dev/./urandom","-jar","/app.jar"]
@@ -23,10 +21,6 @@ services:
     image: mszarlinski/spring-petclinic-customers-service
     container_name: customers-service
     mem_limit: 512M
-    links:
-     - config-server
-     - discovery-server
-     - tracing-server
     depends_on:
      - config-server
      - discovery-server
@@ -38,10 +32,6 @@ services:
     image: mszarlinski/spring-petclinic-visits-service
     container_name: visits-service
     mem_limit: 512M
-    links:
-     - config-server
-     - discovery-server
-     - tracing-server
     depends_on:
      - config-server
      - discovery-server
@@ -53,10 +43,6 @@ services:
     image: mszarlinski/spring-petclinic-vets-service
     container_name: vets-service
     mem_limit: 512M
-    links:
-     - config-server
-     - discovery-server
-     - tracing-server
     depends_on:
      - config-server
      - discovery-server
@@ -68,13 +54,6 @@ services:
     image: mszarlinski/spring-petclinic-api-gateway
     container_name: api-gateway
     mem_limit: 512M
-    links:
-     - config-server
-     - discovery-server
-     - customers-service
-     - visits-service
-     - vets-service
-     - tracing-server
     depends_on:
      - config-server
      - discovery-server
@@ -93,9 +72,6 @@ services:
     image: mszarlinski/spring-petclinic-admin-server
     container_name: admin-server
     mem_limit: 512M
-    links:
-     - config-server
-     - discovery-server
     depends_on:
      - config-server
      - discovery-server

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -3,14 +3,14 @@ services:
   config-server:
     image: mszarlinski/spring-petclinic-config-server
     container_name: config-server
-    mem_limit: 256M
+    mem_limit: 1024M
     ports:
      - 8888:8888
 
   discovery-server:
     image: mszarlinski/spring-petclinic-discovery-server
     container_name: discovery-server
-    mem_limit: 256M
+    mem_limit: 1024M
     links:
      - config-server
     depends_on:
@@ -22,7 +22,7 @@ services:
   customers-service:
     image: mszarlinski/spring-petclinic-customers-service
     container_name: customers-service
-    mem_limit: 256M
+    mem_limit: 1024M
     links:
      - config-server
      - discovery-server
@@ -37,7 +37,7 @@ services:
   visits-service:
     image: mszarlinski/spring-petclinic-visits-service
     container_name: visits-service
-    mem_limit: 256M
+    mem_limit: 1024M
     links:
      - config-server
      - discovery-server
@@ -52,7 +52,7 @@ services:
   vets-service:
     image: mszarlinski/spring-petclinic-vets-service
     container_name: vets-service
-    mem_limit: 256M
+    mem_limit: 1024M
     links:
      - config-server
      - discovery-server
@@ -67,7 +67,7 @@ services:
   api-gateway:
     image: mszarlinski/spring-petclinic-api-gateway
     container_name: api-gateway
-    mem_limit: 256M
+    mem_limit: 1024M
     links:
      - config-server
      - discovery-server
@@ -92,7 +92,7 @@ services:
   admin-server:
     image: mszarlinski/spring-petclinic-admin-server
     container_name: admin-server
-    mem_limit: 256M
+    mem_limit: 1024M
     links:
      - config-server
      - discovery-server

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -4,8 +4,6 @@ services:
     image: mszarlinski/spring-petclinic-config-server
     container_name: config-server
     mem_limit: 1024M
-    ports:
-     - 8888:8888
 
   discovery-server:
     image: mszarlinski/spring-petclinic-discovery-server
@@ -16,8 +14,6 @@ services:
     depends_on:
       - config-server
     entrypoint: ["./dockerize","-wait=tcp://config-server:8888","-timeout=60s","--","java", "-XX:+UnlockExperimentalVMOptions", "-XX:+UseCGroupMemoryLimitForHeap", "-Djava.security.egd=file:/dev/./urandom","-jar","/app.jar"]
-    ports:
-     - 8761:8761
 
   customers-service:
     image: mszarlinski/spring-petclinic-customers-service
@@ -31,8 +27,6 @@ services:
      - config-server
      - discovery-server
     entrypoint: ["./dockerize","-wait=tcp://discovery-server:8761","-timeout=60s","--","java", "-XX:+UnlockExperimentalVMOptions", "-XX:+UseCGroupMemoryLimitForHeap", "-Djava.security.egd=file:/dev/./urandom","-jar","/app.jar"]
-    ports:
-    - 8081:8081
 
   visits-service:
     image: mszarlinski/spring-petclinic-visits-service
@@ -46,8 +40,6 @@ services:
      - config-server
      - discovery-server
     entrypoint: ["./dockerize","-wait=tcp://discovery-server:8761","-timeout=60s","--","java", "-XX:+UnlockExperimentalVMOptions", "-XX:+UseCGroupMemoryLimitForHeap", "-Djava.security.egd=file:/dev/./urandom","-jar","/app.jar"]
-    ports:
-     - 8082:8082
 
   vets-service:
     image: mszarlinski/spring-petclinic-vets-service
@@ -61,8 +53,6 @@ services:
      - config-server
      - discovery-server
     entrypoint: ["./dockerize","-wait=tcp://discovery-server:8761","-timeout=60s","--","java", "-XX:+UnlockExperimentalVMOptions", "-XX:+UseCGroupMemoryLimitForHeap", "-Djava.security.egd=file:/dev/./urandom","-jar","/app.jar"]
-    ports:
-     - 8083:8083
 
   api-gateway:
     image: mszarlinski/spring-petclinic-api-gateway
@@ -100,5 +90,3 @@ services:
      - config-server
      - discovery-server
     entrypoint: ["./dockerize","-wait=tcp://discovery-server:8761","-timeout=60s","--","java", "-XX:+UnlockExperimentalVMOptions", "-XX:+UseCGroupMemoryLimitForHeap", "-Djava.security.egd=file:/dev/./urandom","-jar","/app.jar"]
-    ports:
-     - 9090:9090

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -65,6 +65,8 @@ services:
     image: openzipkin/zipkin
     container_name: tracing-server
     mem_limit: 512M
+    environment:
+    - JAVA_OPTS=-XX:+UnlockExperimentalVMOptions -XX:+UseCGroupMemoryLimitForHeap -Djava.security.egd=file:/dev/./urandom
     ports:
      - 9411:9411
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -3,14 +3,14 @@ services:
   config-server:
     image: mszarlinski/spring-petclinic-config-server
     container_name: config-server
-    mem_limit: 1024M
+    mem_limit: 512M
     ports:
      - 8888:8888
 
   discovery-server:
     image: mszarlinski/spring-petclinic-discovery-server
     container_name: discovery-server
-    mem_limit: 1024M
+    mem_limit: 512M
     links:
      - config-server
     depends_on:
@@ -22,7 +22,7 @@ services:
   customers-service:
     image: mszarlinski/spring-petclinic-customers-service
     container_name: customers-service
-    mem_limit: 1024M
+    mem_limit: 512M
     links:
      - config-server
      - discovery-server
@@ -37,7 +37,7 @@ services:
   visits-service:
     image: mszarlinski/spring-petclinic-visits-service
     container_name: visits-service
-    mem_limit: 1024M
+    mem_limit: 512M
     links:
      - config-server
      - discovery-server
@@ -52,7 +52,7 @@ services:
   vets-service:
     image: mszarlinski/spring-petclinic-vets-service
     container_name: vets-service
-    mem_limit: 1024M
+    mem_limit: 512M
     links:
      - config-server
      - discovery-server
@@ -67,7 +67,7 @@ services:
   api-gateway:
     image: mszarlinski/spring-petclinic-api-gateway
     container_name: api-gateway
-    mem_limit: 1024M
+    mem_limit: 512M
     links:
      - config-server
      - discovery-server
@@ -92,7 +92,7 @@ services:
   admin-server:
     image: mszarlinski/spring-petclinic-admin-server
     container_name: admin-server
-    mem_limit: 1024M
+    mem_limit: 512M
     links:
      - config-server
      - discovery-server

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -4,6 +4,8 @@ services:
     image: mszarlinski/spring-petclinic-config-server
     container_name: config-server
     mem_limit: 1024M
+    ports:
+     - 8888:8888
 
   discovery-server:
     image: mszarlinski/spring-petclinic-discovery-server
@@ -14,6 +16,8 @@ services:
     depends_on:
       - config-server
     entrypoint: ["./dockerize","-wait=tcp://config-server:8888","-timeout=60s","--","java", "-XX:+UnlockExperimentalVMOptions", "-XX:+UseCGroupMemoryLimitForHeap", "-Djava.security.egd=file:/dev/./urandom","-jar","/app.jar"]
+    ports:
+     - 8761:8761
 
   customers-service:
     image: mszarlinski/spring-petclinic-customers-service
@@ -27,6 +31,8 @@ services:
      - config-server
      - discovery-server
     entrypoint: ["./dockerize","-wait=tcp://discovery-server:8761","-timeout=60s","--","java", "-XX:+UnlockExperimentalVMOptions", "-XX:+UseCGroupMemoryLimitForHeap", "-Djava.security.egd=file:/dev/./urandom","-jar","/app.jar"]
+    ports:
+    - 8081:8081
 
   visits-service:
     image: mszarlinski/spring-petclinic-visits-service
@@ -40,6 +46,8 @@ services:
      - config-server
      - discovery-server
     entrypoint: ["./dockerize","-wait=tcp://discovery-server:8761","-timeout=60s","--","java", "-XX:+UnlockExperimentalVMOptions", "-XX:+UseCGroupMemoryLimitForHeap", "-Djava.security.egd=file:/dev/./urandom","-jar","/app.jar"]
+    ports:
+     - 8082:8082
 
   vets-service:
     image: mszarlinski/spring-petclinic-vets-service
@@ -53,6 +61,8 @@ services:
      - config-server
      - discovery-server
     entrypoint: ["./dockerize","-wait=tcp://discovery-server:8761","-timeout=60s","--","java", "-XX:+UnlockExperimentalVMOptions", "-XX:+UseCGroupMemoryLimitForHeap", "-Djava.security.egd=file:/dev/./urandom","-jar","/app.jar"]
+    ports:
+     - 8083:8083
 
   api-gateway:
     image: mszarlinski/spring-petclinic-api-gateway
@@ -90,3 +100,5 @@ services:
      - config-server
      - discovery-server
     entrypoint: ["./dockerize","-wait=tcp://discovery-server:8761","-timeout=60s","--","java", "-XX:+UnlockExperimentalVMOptions", "-XX:+UseCGroupMemoryLimitForHeap", "-Djava.security.egd=file:/dev/./urandom","-jar","/app.jar"]
+    ports:
+     - 9090:9090

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -85,7 +85,7 @@ services:
   tracing-server:
     image: openzipkin/zipkin
     container_name: tracing-server
-    mem_limit: 256M
+    mem_limit: 512M
     ports:
      - 9411:9411
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -15,7 +15,7 @@ services:
      - config-server
     depends_on:
       - config-server
-    entrypoint: ["./wait-for-it.sh","config-server:8888","--timeout=60","--","java", "-XX:+UnlockExperimentalVMOptions", "-XX:+UseCGroupMemoryLimitForHeap", "-Djava.security.egd=file:/dev/./urandom","-jar","/app.jar"]
+    entrypoint: ["./dockerize","-wait=tcp://config-server:8888","-timeout=60s","--","java", "-XX:+UnlockExperimentalVMOptions", "-XX:+UseCGroupMemoryLimitForHeap", "-Djava.security.egd=file:/dev/./urandom","-jar","/app.jar"]
     ports:
      - 8761:8761
 
@@ -30,7 +30,7 @@ services:
     depends_on:
      - config-server
      - discovery-server
-    entrypoint: ["./wait-for-it.sh","discovery-server:8761","--timeout=60","--","java", "-XX:+UnlockExperimentalVMOptions", "-XX:+UseCGroupMemoryLimitForHeap", "-Djava.security.egd=file:/dev/./urandom","-jar","/app.jar"]
+    entrypoint: ["./dockerize","-wait=tcp://discovery-server:8761","-timeout=60s","--","java", "-XX:+UnlockExperimentalVMOptions", "-XX:+UseCGroupMemoryLimitForHeap", "-Djava.security.egd=file:/dev/./urandom","-jar","/app.jar"]
     ports:
     - 8081:8081
 
@@ -45,7 +45,7 @@ services:
     depends_on:
      - config-server
      - discovery-server
-    entrypoint: ["./wait-for-it.sh","discovery-server:8761","--timeout=60","--","java", "-XX:+UnlockExperimentalVMOptions", "-XX:+UseCGroupMemoryLimitForHeap", "-Djava.security.egd=file:/dev/./urandom","-jar","/app.jar"]
+    entrypoint: ["./dockerize","-wait=tcp://discovery-server:8761","-timeout=60s","--","java", "-XX:+UnlockExperimentalVMOptions", "-XX:+UseCGroupMemoryLimitForHeap", "-Djava.security.egd=file:/dev/./urandom","-jar","/app.jar"]
     ports:
      - 8082:8082
 
@@ -60,7 +60,7 @@ services:
     depends_on:
      - config-server
      - discovery-server
-    entrypoint: ["./wait-for-it.sh","discovery-server:8761","--timeout=60","--","java", "-XX:+UnlockExperimentalVMOptions", "-XX:+UseCGroupMemoryLimitForHeap", "-Djava.security.egd=file:/dev/./urandom","-jar","/app.jar"]
+    entrypoint: ["./dockerize","-wait=tcp://discovery-server:8761","-timeout=60s","--","java", "-XX:+UnlockExperimentalVMOptions", "-XX:+UseCGroupMemoryLimitForHeap", "-Djava.security.egd=file:/dev/./urandom","-jar","/app.jar"]
     ports:
      - 8083:8083
 
@@ -78,7 +78,7 @@ services:
     depends_on:
      - config-server
      - discovery-server
-    entrypoint: ["./wait-for-it.sh","discovery-server:8761","--timeout=60","--","java", "-XX:+UnlockExperimentalVMOptions", "-XX:+UseCGroupMemoryLimitForHeap", "-Djava.security.egd=file:/dev/./urandom","-jar","/app.jar"]
+    entrypoint: ["./dockerize","-wait=tcp://discovery-server:8761","-timeout=60s","--","java", "-XX:+UnlockExperimentalVMOptions", "-XX:+UseCGroupMemoryLimitForHeap", "-Djava.security.egd=file:/dev/./urandom","-jar","/app.jar"]
     ports:
      - 8080:8080
 
@@ -99,6 +99,6 @@ services:
     depends_on:
      - config-server
      - discovery-server
-    entrypoint: ["./wait-for-it.sh","discovery-server:8761","--timeout=60","--","java", "-XX:+UnlockExperimentalVMOptions", "-XX:+UseCGroupMemoryLimitForHeap", "-Djava.security.egd=file:/dev/./urandom","-jar","/app.jar"]
+    entrypoint: ["./dockerize","-wait=tcp://discovery-server:8761","-timeout=60s","--","java", "-XX:+UnlockExperimentalVMOptions", "-XX:+UseCGroupMemoryLimitForHeap", "-Djava.security.egd=file:/dev/./urandom","-jar","/app.jar"]
     ports:
      - 9090:9090

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -1,11 +1,14 @@
-FROM openjdk:8
+FROM openjdk:8-jre-alpine
 VOLUME /tmp
-ADD https://raw.githubusercontent.com/vishnubob/wait-for-it/master/wait-for-it.sh wait-for-it.sh
-RUN bash -c 'chmod +x wait-for-it.sh'
+ARG DOCKERIZE_VERSION
 ARG ARTIFACT_NAME
 ARG EXPOSED_PORT
-ADD ${ARTIFACT_NAME}.jar /app.jar
 ENV SPRING_PROFILES_ACTIVE docker
-RUN bash -c 'touch /app.jar'
+
+ADD https://github.com/jwilder/dockerize/releases/download/${DOCKERIZE_VERSION}/dockerize-alpine-linux-amd64-${DOCKERIZE_VERSION}.tar.gz dockerize.tar.gz
+RUN tar xzf dockerize.tar.gz
+RUN chmod +x dockerize
+ADD ${ARTIFACT_NAME}.jar /app.jar
+RUN touch /app.jar
 EXPOSE ${EXPOSED_PORT}
 ENTRYPOINT ["java", "-XX:+UnlockExperimentalVMOptions", "-XX:+UseCGroupMemoryLimitForHeap", "-Djava.security.egd=file:/dev/./urandom","-jar","/app.jar"]

--- a/pom.xml
+++ b/pom.xml
@@ -38,6 +38,7 @@
         <docker.image.prefix>mszarlinski</docker.image.prefix>
         <docker.image.exposed.port>9090</docker.image.exposed.port>
         <docker.image.dockerfile.dir>${basedir}</docker.image.dockerfile.dir>
+        <docker.image.dockerize.version>v0.6.1</docker.image.dockerize.version>
         <docker.plugin.version>0.4.13</docker.plugin.version>
     </properties>
 
@@ -168,6 +169,7 @@
                                 <buildArgs>
                                     <ARTIFACT_NAME>${project.build.finalName}</ARTIFACT_NAME>
                                     <EXPOSED_PORT>${docker.image.exposed.port}</EXPOSED_PORT>
+                                    <DOCKERIZE_VERSION>${docker.image.dockerize.version}</DOCKERIZE_VERSION>
                                 </buildArgs>
                             </configuration>
                         </plugin>


### PR DESCRIPTION
Benefits:
 - Smaller images 200MiB vs 700MiB
 - Faster build times (`mvn clean install -PbuildDocker -DskipTests `) 90s vs 120s
 - dockerize will fail if the timeout is exceeded

The problem with the wait-for-it.sh script is that it will not fail if the timeout is exceeded and contiune with the execution even if the requested service is not available. 

Exposing ports in the docker-compose file is only necessary if the port is accessed outside the docker network and that is only the case for the gateway service.