### PR TITLE
Upgrade to Spring Cloud Finchley SR2 ans Spring Boot 2.0.6

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -6,12 +6,12 @@
     <parent>
         <groupId>org.springframework.boot</groupId>
         <artifactId>spring-boot-starter-parent</artifactId>
-        <version>2.0.5.RELEASE</version>
+        <version>2.0.6.RELEASE</version>
     </parent>
 
     <groupId>org.springframework.samples</groupId>
     <artifactId>spring-petclinic-microservices</artifactId>
-    <version>2.0.5</version>
+    <version>2.0.6</version>
     <name>${project.artifactId}</name>
     <packaging>pom</packaging>
 
@@ -30,7 +30,7 @@
         <assertj.version>3.11.1</assertj.version>
 
         <spring-boot.version>2.0.4.RELEASE</spring-boot.version>
-        <spring-cloud.version>Finchley.SR1</spring-cloud.version>
+        <spring-cloud.version>Finchley.SR2</spring-cloud.version>
         <sleuth.version>2.0.0.RC2</sleuth.version>
 
         <maven-surefire-plugin.version>2.22.0</maven-surefire-plugin.version>

--- a/spring-petclinic-admin-server/pom.xml
+++ b/spring-petclinic-admin-server/pom.xml
@@ -12,7 +12,7 @@
     <parent>
         <groupId>org.springframework.samples</groupId>
         <artifactId>spring-petclinic-microservices</artifactId>
-        <version>2.0.5</version>
+        <version>2.0.6</version>
     </parent>
 
     <properties>

--- a/spring-petclinic-api-gateway/pom.xml
+++ b/spring-petclinic-api-gateway/pom.xml
@@ -11,7 +11,7 @@
     <parent>
         <groupId>org.springframework.samples</groupId>
         <artifactId>spring-petclinic-microservices</artifactId>
-        <version>2.0.5</version>
+        <version>2.0.6</version>
     </parent>
 
     <properties>

--- a/spring-petclinic-config-server/pom.xml
+++ b/spring-petclinic-config-server/pom.xml
@@ -11,7 +11,7 @@
     <parent>
         <groupId>org.springframework.samples</groupId>
         <artifactId>spring-petclinic-microservices</artifactId>
-        <version>2.0.5</version>
+        <version>2.0.6</version>
     </parent>
 
     <properties>

--- a/spring-petclinic-customers-service/pom.xml
+++ b/spring-petclinic-customers-service/pom.xml
@@ -11,7 +11,7 @@
 	<parent>
 		<groupId>org.springframework.samples</groupId>
 		<artifactId>spring-petclinic-microservices</artifactId>
-		<version>2.0.5</version>
+		<version>2.0.6</version>
 	</parent>
 
     <properties>

--- a/spring-petclinic-discovery-server/pom.xml
+++ b/spring-petclinic-discovery-server/pom.xml
@@ -11,7 +11,7 @@
     <parent>
         <groupId>org.springframework.samples</groupId>
         <artifactId>spring-petclinic-microservices</artifactId>
-        <version>2.0.5</version>
+        <version>2.0.6</version>
     </parent>
 
     <properties>

--- a/spring-petclinic-vets-service/pom.xml
+++ b/spring-petclinic-vets-service/pom.xml
@@ -11,7 +11,7 @@
 	<parent>
 		<groupId>org.springframework.samples</groupId>
 		<artifactId>spring-petclinic-microservices</artifactId>
-		<version>2.0.5</version>
+		<version>2.0.6</version>
 	</parent>
 
     <properties>

--- a/spring-petclinic-visits-service/pom.xml
+++ b/spring-petclinic-visits-service/pom.xml
@@ -11,7 +11,7 @@
     <parent>
         <groupId>org.springframework.samples</groupId>
         <artifactId>spring-petclinic-microservices</artifactId>
-        <version>2.0.5</version>
+        <version>2.0.6</version>
     </parent>
 
     <properties>


### PR DESCRIPTION
Spring Cloud Finchley.SR2 release note:
http://spring.io/blog/2018/10/24/spring-cloud-finchley-sr2-is-available