### PR TITLE
Implement circuit breaker with Spring Cloud Netflix Hystrix

### DIFF
--- a/README.md
+++ b/README.md
@@ -90,7 +90,7 @@ the host and port of your MySQL JDBC connection string.
 | Service Discovery       | [Eureka server](spring-petclinic-discovery-server) and [Service discovery client](spring-petclinic-vets-service/src/main/java/org/springframework/samples/petclinic/vets/VetsServiceApplication.java) |
 | API Gateway             | [Zuul reverse proxy](spring-petclinic-api-gateway/src/main/java/org/springframework/samples/petclinic/api/ApiGatewayApplication.java) and [Routing configuration](https://github.com/spring-petclinic/spring-petclinic-microservices-config/blob/master/api-gateway.yml) |
 | Docker Compose          | [Spring Boot with Docker guide](https://spring.io/guides/gs/spring-boot-docker/) and [docker-compose file](docker-compose.yml) |
-| Circuit Breaker         | TBD |
+| Circuit Breaker         | [Circuit Breaker with Hystrix guide](https://spring.io/guides/gs/circuit-breaker/) and [fallback method configuration](spring-petclinic-api-gateway/src/main/java/org/springframework/samples/petclinic/api/application/VisitsServiceClient.java) |
 | Graphite Monitoring     | TBD |
 
  Front-end module  | Files |

--- a/spring-petclinic-api-gateway/pom.xml
+++ b/spring-petclinic-api-gateway/pom.xml
@@ -73,6 +73,10 @@
             <groupId>org.springframework.cloud</groupId>
             <artifactId>spring-cloud-starter-netflix-zuul</artifactId>
         </dependency>
+        <dependency>
+            <groupId>org.springframework.cloud</groupId>
+            <artifactId>spring-cloud-starter-netflix-hystrix</artifactId>
+        </dependency>
 
         <!-- Third parties -->
         <dependency>

--- a/spring-petclinic-api-gateway/src/main/java/org/springframework/samples/petclinic/api/ApiGatewayApplication.java
+++ b/spring-petclinic-api-gateway/src/main/java/org/springframework/samples/petclinic/api/ApiGatewayApplication.java
@@ -17,6 +17,7 @@ package org.springframework.samples.petclinic.api;
 
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
+import org.springframework.cloud.client.circuitbreaker.EnableCircuitBreaker;
 import org.springframework.cloud.client.discovery.EnableDiscoveryClient;
 import org.springframework.cloud.client.loadbalancer.LoadBalanced;
 import org.springframework.cloud.netflix.zuul.EnableZuulProxy;
@@ -28,6 +29,7 @@ import org.springframework.web.client.RestTemplate;
  */
 @EnableZuulProxy
 @EnableDiscoveryClient
+@EnableCircuitBreaker
 @SpringBootApplication
 public class ApiGatewayApplication {
 

--- a/spring-petclinic-api-gateway/src/main/java/org/springframework/samples/petclinic/api/application/VisitsServiceClient.java
+++ b/spring-petclinic-api-gateway/src/main/java/org/springframework/samples/petclinic/api/application/VisitsServiceClient.java
@@ -15,8 +15,11 @@
  */
 package org.springframework.samples.petclinic.api.application;
 
+import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
+
+import com.netflix.hystrix.contrib.javanica.annotation.HystrixCommand;
 import lombok.RequiredArgsConstructor;
 import org.springframework.samples.petclinic.api.dto.VisitDetails;
 import org.springframework.samples.petclinic.api.dto.Visits;
@@ -38,6 +41,7 @@ public class VisitsServiceClient {
 
     private final RestTemplate loadBalancedRestTemplate;
 
+    @HystrixCommand(fallbackMethod = "emptyVisitsForPets")
     public Map<Integer, List<VisitDetails>> getVisitsForPets(final List<Integer> petIds) {
         UriComponentsBuilder builder = fromHttpUrl("http://visits-service/pets/visits")
             .queryParam("petId", joinIds(petIds));
@@ -50,5 +54,9 @@ public class VisitsServiceClient {
 
     private String joinIds(List<Integer> petIds) {
         return petIds.stream().map(Object::toString).collect(joining(","));
+    }
+
+    public Map<Integer, List<VisitDetails>> emptyVisitsForPets(List<Integer> petIds) {
+        return new HashMap<>();
     }
 }

--- a/spring-petclinic-api-gateway/src/main/java/org/springframework/samples/petclinic/api/application/VisitsServiceClient.java
+++ b/spring-petclinic-api-gateway/src/main/java/org/springframework/samples/petclinic/api/application/VisitsServiceClient.java
@@ -15,7 +15,7 @@
  */
 package org.springframework.samples.petclinic.api.application;
 
-import java.util.HashMap;
+import java.util.Collections;
 import java.util.List;
 import java.util.Map;
 
@@ -57,6 +57,6 @@ public class VisitsServiceClient {
     }
 
     public Map<Integer, List<VisitDetails>> emptyVisitsForPets(List<Integer> petIds) {
-        return new HashMap<>();
+        return Collections.emptyMap();
     }
 }

--- a/spring-petclinic-api-gateway/src/main/java/org/springframework/samples/petclinic/api/application/VisitsServiceClient.java
+++ b/spring-petclinic-api-gateway/src/main/java/org/springframework/samples/petclinic/api/application/VisitsServiceClient.java
@@ -56,7 +56,7 @@ public class VisitsServiceClient {
         return petIds.stream().map(Object::toString).collect(joining(","));
     }
 
-    public Map<Integer, List<VisitDetails>> emptyVisitsForPets(List<Integer> petIds) {
+    private Map<Integer, List<VisitDetails>> emptyVisitsForPets(List<Integer> petIds) {
         return Collections.emptyMap();
     }
 }

--- a/spring-petclinic-api-gateway/src/test/java/org/springframework/samples/petclinic/api/application/VisitsServiceClientTest.java
+++ b/spring-petclinic-api-gateway/src/test/java/org/springframework/samples/petclinic/api/application/VisitsServiceClientTest.java
@@ -63,11 +63,7 @@ class VisitsServiceClientTest {
 
         Map<Integer, List<VisitDetails>> visits = visitsServiceClient.getVisitsForPets(Collections.singletonList(1));
 
-        assertNotNull(visits);
-        assertEquals(1, visits.size());
-        assertNotNull(visits.get(1));
-        assertEquals(1, visits.get(PET_ID).size());
-        assertDescriptionEquals(visits.get(PET_ID),"test visit");
+        assertVisitDescriptionEquals(visits, PET_ID,"test visit");
     }
 
     /**
@@ -81,12 +77,14 @@ class VisitsServiceClientTest {
 
         Map<Integer, List<VisitDetails>> visits = visitsServiceClient.getVisitsForPets(Collections.singletonList(1));
 
-        assertNotNull(visits);
         assertEquals(0, visits.size());
     }
 
-    private void assertDescriptionEquals(List<VisitDetails> visitDetails, String description) {
-        assertEquals(description, visitDetails.get(0).getDescription());
+    private void assertVisitDescriptionEquals(Map<Integer, List<VisitDetails>> visits, int petId, String description) {
+        assertEquals(1, visits.size());
+        assertNotNull(visits.get(1));
+        assertEquals(1, visits.get(petId).size());
+        assertEquals(description, visits.get(petId).get(0).getDescription());
     }
 
 }

--- a/spring-petclinic-api-gateway/src/test/java/org/springframework/samples/petclinic/api/application/VisitsServiceClientTest.java
+++ b/spring-petclinic-api-gateway/src/test/java/org/springframework/samples/petclinic/api/application/VisitsServiceClientTest.java
@@ -31,6 +31,8 @@ import static org.springframework.test.web.client.response.MockRestResponseCreat
 @ContextConfiguration(classes = {VisitsServiceClient.class})
 class VisitsServiceClientTest {
 
+    private static final Integer PET_ID = 1;
+
     @Autowired
     private VisitsServiceClient visitsServiceClient;
 
@@ -64,8 +66,8 @@ class VisitsServiceClientTest {
         assertNotNull(visits);
         assertEquals(1, visits.size());
         assertNotNull(visits.get(1));
-        assertEquals(1, visits.get(1).size());
-        assertEquals("test visit", visits.get(1).get(0).getDescription());
+        assertEquals(1, visits.get(PET_ID).size());
+        assertDescriptionEquals(visits.get(PET_ID),"test visit");
     }
 
     /**
@@ -81,6 +83,10 @@ class VisitsServiceClientTest {
 
         assertNotNull(visits);
         assertEquals(0, visits.size());
+    }
+
+    private void assertDescriptionEquals(List<VisitDetails> visitDetails, String description) {
+        assertEquals(description, visitDetails.get(0).getDescription());
     }
 
 }


### PR DESCRIPTION
In the `api-gateway`module, I've added a circuit breaker to the `VisitsServiceClient::getVisitsForPets` method. When the `pets-service` is down (or not started), the owner's detail page is now displayed without the visits.
I'm aware about all other methods where we could apply the circuit breaker pattern.

Metrics are available at the URL: http://localhost:8080/actuator/hystrix.stream

We could add a Hystrix Dashboard in another Maven module. I've tried to add it to the `api-gaeway' module but I had some conflicts with the jQuery webjar.