### PR TITLE
Migrate from Netflix Zuul to Spring Cloud Gateway #117

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,7 +30,7 @@ In order to start entire infrastructure using Docker, you have to build images b
 from a project root. Once images are ready, you can start them with a single command
 `docker-compose up`. Containers startup order is coordinated with [`dockerize` script](https://github.com/jwilder/dockerize). 
 After starting services it takes a while for API Gateway to be in sync with service registry,
-so don't be scared of initial Zuul timeouts. You can track services availability using Eureka dashboard
+so don't be scared of initial Spring Cloud Gateway timeouts. You can track services availability using Eureka dashboard
 available by default at http://localhost:8761.
 
 *NOTE: Under MacOSX or Windows, make sure that the Docker VM has enough memory to run the microservices. The default settings
@@ -126,7 +126,7 @@ All those three REST controllers `OwnerResource`, `PetResource` and `VisitResour
 |---------------------------------|------------|
 | Configuration server            | [Config server properties](spring-petclinic-config-server/src/main/resources/application.yml) and [Configuration repository] |
 | Service Discovery               | [Eureka server](spring-petclinic-discovery-server) and [Service discovery client](spring-petclinic-vets-service/src/main/java/org/springframework/samples/petclinic/vets/VetsServiceApplication.java) |
-| API Gateway                     | [Zuul reverse proxy](spring-petclinic-api-gateway/src/main/java/org/springframework/samples/petclinic/api/ApiGatewayApplication.java) and [Routing configuration](https://github.com/spring-petclinic/spring-petclinic-microservices-config/blob/master/api-gateway.yml) |
+| API Gateway                     | [Spring Cloud Gateway starter](spring-petclinic-api-gateway/pom.xml) and [Routing configuration](/spring-petclinic-api-gateway/src/main/resources/application.yml) |
 | Docker Compose                  | [Spring Boot with Docker guide](https://spring.io/guides/gs/spring-boot-docker/) and [docker-compose file](docker-compose.yml) |
 | Circuit Breaker                 | [Hystrix fallback method](spring-petclinic-api-gateway/src/main/java/org/springframework/samples/petclinic/api/application/VisitsServiceClient.java)  |
 | Grafana / Prometheus Monitoring | [Micrometer implementation](https://micrometer.io/), [Spring Boot Actuator Production Ready Metrics] |

--- a/spring-petclinic-api-gateway/pom.xml
+++ b/spring-petclinic-api-gateway/pom.xml
@@ -44,10 +44,6 @@
         </dependency>
         <dependency>
             <groupId>org.springframework.boot</groupId>
-            <artifactId>spring-boot-starter-web</artifactId>
-        </dependency>
-        <dependency>
-            <groupId>org.springframework.boot</groupId>
             <artifactId>spring-boot-starter-test</artifactId>
             <scope>test</scope>
         </dependency>
@@ -71,7 +67,7 @@
         </dependency>
         <dependency>
             <groupId>org.springframework.cloud</groupId>
-            <artifactId>spring-cloud-starter-netflix-zuul</artifactId>
+            <artifactId>spring-cloud-starter-gateway</artifactId>
         </dependency>
         <dependency>
             <groupId>org.springframework.cloud</groupId>

--- a/spring-petclinic-api-gateway/src/main/java/org/springframework/samples/petclinic/api/ApiGatewayApplication.java
+++ b/spring-petclinic-api-gateway/src/main/java/org/springframework/samples/petclinic/api/ApiGatewayApplication.java
@@ -15,19 +15,26 @@
  */
 package org.springframework.samples.petclinic.api;
 
+import org.springframework.beans.factory.annotation.Value;
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
 import org.springframework.cloud.client.circuitbreaker.EnableCircuitBreaker;
 import org.springframework.cloud.client.discovery.EnableDiscoveryClient;
 import org.springframework.cloud.client.loadbalancer.LoadBalanced;
-import org.springframework.cloud.netflix.zuul.EnableZuulProxy;
 import org.springframework.context.annotation.Bean;
+import org.springframework.core.io.ClassPathResource;
+import org.springframework.core.io.Resource;
+import org.springframework.http.MediaType;
 import org.springframework.web.client.RestTemplate;
+import org.springframework.web.reactive.function.server.RequestPredicates;
+import org.springframework.web.reactive.function.server.RouterFunction;
+import org.springframework.web.reactive.function.server.RouterFunctions;
+import org.springframework.web.reactive.function.server.ServerResponse;
+
 
 /**
  * @author Maciej Szarlinski
  */
-@EnableZuulProxy
 @EnableDiscoveryClient
 @EnableCircuitBreaker
 @SpringBootApplication
@@ -41,5 +48,20 @@ public class ApiGatewayApplication {
     @LoadBalanced
     RestTemplate loadBalancedRestTemplate() {
         return new RestTemplate();
+    }
+
+    @Value("classpath:/static/index.html")
+    private Resource indexHtml;
+
+    /**
+     * workaround solution for forwarding to index.html
+     * @see <a href="https://github.com/spring-projects/spring-boot/issues/9785">#9785</a>
+     */
+    @Bean
+    RouterFunction<?> routerFunction() {
+        RouterFunction router = RouterFunctions.resources("/**", new ClassPathResource("static/"))
+            .andRoute(RequestPredicates.GET("/"),
+                request -> ServerResponse.ok().contentType(MediaType.TEXT_HTML).syncBody(indexHtml));
+        return router;
     }
 }

--- a/spring-petclinic-api-gateway/src/main/java/org/springframework/samples/petclinic/api/boundary/web/ApiGatewayController.java
+++ b/spring-petclinic-api-gateway/src/main/java/org/springframework/samples/petclinic/api/boundary/web/ApiGatewayController.java
@@ -25,6 +25,7 @@ import org.springframework.samples.petclinic.api.application.VisitsServiceClient
 import org.springframework.samples.petclinic.api.dto.VisitDetails;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 
 
@@ -35,6 +36,7 @@ import static java.util.Collections.emptyList;
  */
 @RestController
 @RequiredArgsConstructor
+@RequestMapping("/api/gateway")
 public class ApiGatewayController {
 
     private final CustomersServiceClient customersServiceClient;

--- a/spring-petclinic-api-gateway/src/main/resources/application.yml
+++ b/spring-petclinic-api-gateway/src/main/resources/application.yml
@@ -1,8 +1,22 @@
-zuul:
-  prefix: /api
-  ignoredServices: '*'
-  routes:
-    vets-service: /vet/**
-    visits-service: /visit/**
-    customers-service: /customer/**
-    api-gateway: /gateway/**
+spring:
+  cloud:
+    gateway:
+      routes:
+        - id: vets-service
+          uri: lb://vets-service
+          predicates:
+            - Path=/api/vet/**
+          filters:
+            - StripPrefix=2
+        - id: visits-service
+          uri: lb://visits-service
+          predicates:
+            - Path=/api/visit/**
+          filters:
+            - StripPrefix=2
+        - id: customers-service
+          uri: lb://customers-service
+          predicates:
+            - Path=/api/customer/**
+          filters:
+            - StripPrefix=2


### PR DESCRIPTION
Started from Spring Cloud Greenwich, the Spring Cloud team recommend to migrate from Zuul 1 to Spring Cloud Gateway.
For the `spring-petclinic-api-gateway` module, a prerequisite was to migrage from Spring MVC to Spring WebFlux.