### PR TITLE
Removed expired jvm flag -XX:+UseCGroupMemoryLimitForHeap from trace service

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -67,7 +67,7 @@ services:
     container_name: tracing-server
     mem_limit: 512M
     environment:
-    - JAVA_OPTS=-XX:+UnlockExperimentalVMOptions -XX:+UseCGroupMemoryLimitForHeap -Djava.security.egd=file:/dev/./urandom
+    - JAVA_OPTS=-XX:+UnlockExperimentalVMOptions -Djava.security.egd=file:/dev/./urandom
     ports:
      - 9411:9411
 


### PR DESCRIPTION
It appears that the openzipkin/zipkin docker image in the docker hub was upgraded to Java 11 and the -XX:+UseCGroupMemoryLimitForHeap is no longer a valid option. I believe it just needs to be removed.
The startup error is
```
tracing-server       | Unrecognized VM option 'UseCGroupMemoryLimitForHeap'
tracing-server       | Error: Could not create the Java Virtual Machine.
tracing-server       | Error: A fatal exception has occurred. Program will exit.
```