### PR TITLE
Java 11 version

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,6 +2,9 @@
 target/
 !.mvn/wrapper/maven-wrapper.jar
 
+# Jenv
+.java-version
+
 # Eclipse
 .settings/
 .classpath

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -14,7 +14,7 @@ services:
     mem_limit: 512M
     depends_on:
       - config-server
-    entrypoint: ["./dockerize","-wait=tcp://config-server:8888","-timeout=60s","--","java", "-XX:+UnlockExperimentalVMOptions", "-XX:+UseCGroupMemoryLimitForHeap", "-Djava.security.egd=file:/dev/./urandom","-jar","/app.jar"]
+    entrypoint: ["./dockerize","-wait=tcp://config-server:8888","-timeout=60s","--","java", "-Djava.security.egd=file:/dev/./urandom","-jar","/app.jar"]
     ports:
      - 8761:8761
 
@@ -25,7 +25,7 @@ services:
     depends_on:
      - config-server
      - discovery-server
-    entrypoint: ["./dockerize","-wait=tcp://discovery-server:8761","-timeout=60s","--","java", "-XX:+UnlockExperimentalVMOptions", "-XX:+UseCGroupMemoryLimitForHeap", "-Djava.security.egd=file:/dev/./urandom","-jar","/app.jar"]
+    entrypoint: ["./dockerize","-wait=tcp://discovery-server:8761","-timeout=60s","--","java", "-Djava.security.egd=file:/dev/./urandom","-jar","/app.jar"]
     ports:
     - 8081:8081
 
@@ -36,7 +36,7 @@ services:
     depends_on:
      - config-server
      - discovery-server
-    entrypoint: ["./dockerize","-wait=tcp://discovery-server:8761","-timeout=60s","--","java", "-XX:+UnlockExperimentalVMOptions", "-XX:+UseCGroupMemoryLimitForHeap", "-Djava.security.egd=file:/dev/./urandom","-jar","/app.jar"]
+    entrypoint: ["./dockerize","-wait=tcp://discovery-server:8761","-timeout=60s","--","java", "-Djava.security.egd=file:/dev/./urandom","-jar","/app.jar"]
     ports:
      - 8082:8082
 
@@ -47,7 +47,7 @@ services:
     depends_on:
      - config-server
      - discovery-server
-    entrypoint: ["./dockerize","-wait=tcp://discovery-server:8761","-timeout=60s","--","java", "-XX:+UnlockExperimentalVMOptions", "-XX:+UseCGroupMemoryLimitForHeap", "-Djava.security.egd=file:/dev/./urandom","-jar","/app.jar"]
+    entrypoint: ["./dockerize","-wait=tcp://discovery-server:8761","-timeout=60s","--","java", "-Djava.security.egd=file:/dev/./urandom","-jar","/app.jar"]
     ports:
      - 8083:8083
 
@@ -58,7 +58,7 @@ services:
     depends_on:
      - config-server
      - discovery-server
-    entrypoint: ["./dockerize","-wait=tcp://discovery-server:8761","-timeout=60s","--","java", "-XX:+UnlockExperimentalVMOptions", "-XX:+UseCGroupMemoryLimitForHeap", "-Djava.security.egd=file:/dev/./urandom","-jar","/app.jar"]
+    entrypoint: ["./dockerize","-wait=tcp://discovery-server:8761","-timeout=60s","--","java", "-Djava.security.egd=file:/dev/./urandom","-jar","/app.jar"]
     ports:
      - 8080:8080
 
@@ -78,7 +78,7 @@ services:
     depends_on:
      - config-server
      - discovery-server
-    entrypoint: ["./dockerize","-wait=tcp://discovery-server:8761","-timeout=60s","--","java", "-XX:+UnlockExperimentalVMOptions", "-XX:+UseCGroupMemoryLimitForHeap", "-Djava.security.egd=file:/dev/./urandom","-jar","/app.jar"]
+    entrypoint: ["./dockerize","-wait=tcp://discovery-server:8761","-timeout=60s","--","java", "-Djava.security.egd=file:/dev/./urandom","-jar","/app.jar"]
     ports:
      - 9090:9090
 
@@ -89,7 +89,7 @@ services:
     depends_on:
      - config-server
      - discovery-server
-    entrypoint: ["./dockerize","-wait=tcp://discovery-server:8761","-timeout=60s","--","java", "-XX:+UnlockExperimentalVMOptions", "-XX:+UseCGroupMemoryLimitForHeap", "-Djava.security.egd=file:/dev/./urandom","-jar","/app.jar"]
+    entrypoint: ["./dockerize","-wait=tcp://discovery-server:8761","-timeout=60s","--","java", "-Djava.security.egd=file:/dev/./urandom","-jar","/app.jar"]
     ports:
      - 7979:7979
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -2,14 +2,14 @@ version: '2'
 
 services:
   config-server:
-    image: mszarlinski/spring-petclinic-config-server
+    image: springcommunity/spring-petclinic-config-server
     container_name: config-server
     mem_limit: 512M
     ports:
      - 8888:8888
 
   discovery-server:
-    image: mszarlinski/spring-petclinic-discovery-server
+    image: springcommunity/spring-petclinic-discovery-server
     container_name: discovery-server
     mem_limit: 512M
     depends_on:
@@ -19,7 +19,7 @@ services:
      - 8761:8761
 
   customers-service:
-    image: mszarlinski/spring-petclinic-customers-service
+    image: springcommunity/spring-petclinic-customers-service
     container_name: customers-service
     mem_limit: 512M
     depends_on:
@@ -30,7 +30,7 @@ services:
     - 8081:8081
 
   visits-service:
-    image: mszarlinski/spring-petclinic-visits-service
+    image: springcommunity/spring-petclinic-visits-service
     container_name: visits-service
     mem_limit: 512M
     depends_on:
@@ -41,7 +41,7 @@ services:
      - 8082:8082
 
   vets-service:
-    image: mszarlinski/spring-petclinic-vets-service
+    image: springcommunity/spring-petclinic-vets-service
     container_name: vets-service
     mem_limit: 512M
     depends_on:
@@ -52,7 +52,7 @@ services:
      - 8083:8083
 
   api-gateway:
-    image: mszarlinski/spring-petclinic-api-gateway
+    image: springcommunity/spring-petclinic-api-gateway
     container_name: api-gateway
     mem_limit: 512M
     depends_on:
@@ -72,7 +72,7 @@ services:
      - 9411:9411
 
   admin-server:
-    image: mszarlinski/spring-petclinic-admin-server
+    image: springcommunity/spring-petclinic-admin-server
     container_name: admin-server
     mem_limit: 512M
     depends_on:
@@ -83,7 +83,7 @@ services:
      - 9090:9090
 
   hystrix-dashboard:
-    image: mszarlinski/spring-petclinic-hystrix-dashboard
+    image: springcommunity/spring-petclinic-hystrix-dashboard
     container_name: hystrix-dashboard
     mem_limit: 512M
     depends_on:

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -1,4 +1,4 @@
-FROM openjdk:8-jre-alpine
+FROM openjdk:11-jre
 VOLUME /tmp
 ARG DOCKERIZE_VERSION
 ARG ARTIFACT_NAME
@@ -11,4 +11,4 @@ RUN chmod +x dockerize
 ADD ${ARTIFACT_NAME}.jar /app.jar
 RUN touch /app.jar
 EXPOSE ${EXPOSED_PORT}
-ENTRYPOINT ["java", "-XX:+UnlockExperimentalVMOptions", "-XX:+UseCGroupMemoryLimitForHeap", "-Djava.security.egd=file:/dev/./urandom","-jar","/app.jar"]
+ENTRYPOINT ["java", "-Djava.security.egd=file:/dev/./urandom","-jar","/app.jar"]

--- a/pom.xml
+++ b/pom.xml
@@ -40,7 +40,7 @@
         <docker.image.exposed.port>9090</docker.image.exposed.port>
         <docker.image.dockerfile.dir>${basedir}</docker.image.dockerfile.dir>
         <docker.image.dockerize.version>v0.6.1</docker.image.dockerize.version>
-        <docker.plugin.version>0.4.13</docker.plugin.version>
+        <docker.plugin.version>1.2.0</docker.plugin.version>
     </properties>
 
     <dependencyManagement>

--- a/pom.xml
+++ b/pom.xml
@@ -36,7 +36,7 @@
 
         <maven-surefire-plugin.version>2.22.0</maven-surefire-plugin.version>
 
-        <docker.image.prefix>mszarlinski</docker.image.prefix>
+        <docker.image.prefix>springcommunity</docker.image.prefix>
         <docker.image.exposed.port>9090</docker.image.exposed.port>
         <docker.image.dockerfile.dir>${basedir}</docker.image.dockerfile.dir>
         <docker.image.dockerize.version>v0.6.1</docker.image.dockerize.version>
@@ -154,6 +154,8 @@
                             <configuration>
                                 <imageName>${docker.image.prefix}/${project.artifactId}</imageName>
                                 <dockerDirectory>${docker.image.dockerfile.dir}</dockerDirectory>
+                                <serverId>docker-hub</serverId>
+                                <registryUrl>https://index.docker.io/v1/</registryUrl>
                                 <resources>
                                     <resource>
                                         <targetPath>/</targetPath>

--- a/spring-petclinic-api-gateway/pom.xml
+++ b/spring-petclinic-api-gateway/pom.xml
@@ -158,6 +158,12 @@
                         <artifactId>bootstrap</artifactId>
                         <version>${webjars-bootstrap.version}</version>
                     </dependency>
+                    <!-- Some tweak for wro4j 1.8 compatibility with Java 9+-->
+                    <dependency>
+                        <groupId>org.mockito</groupId>
+                        <artifactId>mockito-core</artifactId>
+                        <version>${mockito.version}</version>
+                    </dependency>
                 </dependencies>
             </plugin>
         </plugins>

--- a/spring-petclinic-api-gateway/pom.xml
+++ b/spring-petclinic-api-gateway/pom.xml
@@ -158,7 +158,8 @@
                         <artifactId>bootstrap</artifactId>
                         <version>${webjars-bootstrap.version}</version>
                     </dependency>
-                    <!-- Some tweak for wro4j 1.8 compatibility with Java 9+-->
+                    <!-- Some tweak for wro4j 1.8 compatibility with Java 9+ -->
+                    <!-- See https://github.com/wro4j/wro4j/issues/1039 -->
                     <dependency>
                         <groupId>org.mockito</groupId>
                         <artifactId>mockito-core</artifactId>

--- a/spring-petclinic-discovery-server/pom.xml
+++ b/spring-petclinic-discovery-server/pom.xml
@@ -48,6 +48,12 @@
             <artifactId>junit-jupiter-engine</artifactId>
             <scope>test</scope>
         </dependency>
+
+        <!-- JAXB is required since Java 9 -->
+        <dependency>
+            <groupId>org.glassfish.jaxb</groupId>
+            <artifactId>jaxb-runtime</artifactId>
+        </dependency>
     </dependencies>
 
     <profiles>


### PR DESCRIPTION
@notsureifkevin, @pwittrock, the new `release/java11` branch will host a version of Spring Petclinic Microservices based on OpenJDK 11.
I've upgraded the maven-docker-plugin from 0.4.13 to 1.2.0 (still have a GCR warning during the build).
We could

I've also used a new prefix (I will report it to develop) in order to publish Docker image to Docker Hub in an a neutral organization.
@mszarlinski I've created the `springcommunity` organization into Docker Hub. Please could you confirm your DockerHub login is `springcommunity`