### PR TITLE
Add mysql container to docker-compose

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -18,11 +18,21 @@ services:
     ports:
      - 8761:8761
 
+  mysql-db:
+    image: mysql:5.7.8
+    container_name: mysql-db
+    environment:
+     - MYSQL_ROOT_PASSWORD=petclinic
+     - MYSQL_DATABASE=petclinic
+    ports:
+     - 3306:3306
+
   customers-service:
     image: springcommunity/spring-petclinic-customers-service
     container_name: customers-service
     mem_limit: 512M
     depends_on:
+     - mysql-db
      - config-server
      - discovery-server
     entrypoint: ["./dockerize","-wait=tcp://discovery-server:8761","-timeout=60s","--","java", "-XX:+UnlockExperimentalVMOptions", "-XX:+UseCGroupMemoryLimitForHeap", "-Djava.security.egd=file:/dev/./urandom","-jar","/app.jar"]
@@ -34,6 +44,7 @@ services:
     container_name: visits-service
     mem_limit: 512M
     depends_on:
+     - mysql-db
      - config-server
      - discovery-server
     entrypoint: ["./dockerize","-wait=tcp://discovery-server:8761","-timeout=60s","--","java", "-XX:+UnlockExperimentalVMOptions", "-XX:+UseCGroupMemoryLimitForHeap", "-Djava.security.egd=file:/dev/./urandom","-jar","/app.jar"]
@@ -45,6 +56,7 @@ services:
     container_name: vets-service
     mem_limit: 512M
     depends_on:
+     - mysql-db
      - config-server
      - discovery-server
     entrypoint: ["./dockerize","-wait=tcp://discovery-server:8761","-timeout=60s","--","java", "-XX:+UnlockExperimentalVMOptions", "-XX:+UseCGroupMemoryLimitForHeap", "-Djava.security.egd=file:/dev/./urandom","-jar","/app.jar"]


### PR DESCRIPTION
Closes: #116 
This will spin up a mysql container called `mysql-db` from `docker-compose up`. If `mysql` is not added as an active profile in the `Dockerfile`, the db is still spun up but services will use h2. Adding `mysql` to the `Dockerfile` will grab new mysql configuration from the config server added in [this PR](https://github.com/spring-petclinic/spring-petclinic-microservices-config/pull/9)