### PR TITLE
Update Dockerfile and fix layers caching

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -1,14 +1,19 @@
 FROM openjdk:8-jre-alpine
 VOLUME /tmp
-ARG DOCKERIZE_VERSION
-ARG ARTIFACT_NAME
-ARG EXPOSED_PORT
-ENV SPRING_PROFILES_ACTIVE docker
 
-ADD https://github.com/jwilder/dockerize/releases/download/${DOCKERIZE_VERSION}/dockerize-alpine-linux-amd64-${DOCKERIZE_VERSION}.tar.gz dockerize.tar.gz
+# Download dockerize and cache that layer
+ARG DOCKERIZE_VERSION
+RUN wget -O dockerize.tar.gz https://github.com/jwilder/dockerize/releases/download/${DOCKERIZE_VERSION}/dockerize-alpine-linux-amd64-${DOCKERIZE_VERSION}.tar.gz
 RUN tar xzf dockerize.tar.gz
 RUN chmod +x dockerize
+
+# This is the first layer that won't be cached
+ARG ARTIFACT_NAME
 ADD ${ARTIFACT_NAME}.jar /app.jar
-RUN touch /app.jar
+
+ARG EXPOSED_PORT
 EXPOSE ${EXPOSED_PORT}
+
+ENV SPRING_PROFILES_ACTIVE docker
+
 ENTRYPOINT ["java", "-XX:+UnlockExperimentalVMOptions", "-XX:+UseCGroupMemoryLimitForHeap", "-Djava.security.egd=file:/dev/./urandom","-jar","/app.jar"]


### PR DESCRIPTION
I updated the dockerfile - replaced `ADD` with `RUN` and thus allowed caching of the Dockerize.

`RUN` hashes just the URL, on the other hand `ADD` computes hash from the downloaded file so the file must be downloaded every time.
```
Step 1/12 : FROM openjdk:8-jre-alpine

 ---> f7a292bbb70c
Step 2/12 : VOLUME /tmp

 ---> Using cache
 ---> 674131380226
Step 3/12 : ARG DOCKERIZE_VERSION

 ---> Using cache
 ---> 4e71f5a79327
Step 4/12 : RUN wget -O dockerize.tar.gz https://github.com/jwilder/dockerize/releases/download/${DOCKERIZE_VERSION}/dockerize-alpine-linux-amd64-${DOCKERIZE_VERSION}.tar.gz

 ---> Using cache
 ---> f04603ca89a8
Step 5/12 : RUN tar xzf dockerize.tar.gz

 ---> Using cache
 ---> b3b45f125cc1
Step 6/12 : RUN chmod +x dockerize

 ---> Using cache
 ---> 06b6c870566e
Step 7/12 : ARG ARTIFACT_NAME

 ---> Using cache
 ---> 834646a63ccb
```
This fixes https://github.com/spring-petclinic/spring-petclinic-microservices/issues/136