### PR TITLE
Use Spring Boot layered jars to optimize Docker images

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -14,7 +14,7 @@ services:
     mem_limit: 512M
     depends_on:
       - config-server
-    entrypoint: ["./dockerize","-wait=tcp://config-server:8888","-timeout=60s","--","java", "-XX:+UnlockExperimentalVMOptions", "-XX:+UseCGroupMemoryLimitForHeap", "-Djava.security.egd=file:/dev/./urandom","-jar","/app.jar"]
+    entrypoint: ["./dockerize","-wait=tcp://config-server:8888","-timeout=60s","--","java", "org.springframework.boot.loader.JarLauncher"]
     ports:
      - 8761:8761
 
@@ -25,7 +25,7 @@ services:
     depends_on:
      - config-server
      - discovery-server
-    entrypoint: ["./dockerize","-wait=tcp://discovery-server:8761","-timeout=60s","--","java", "-XX:+UnlockExperimentalVMOptions", "-XX:+UseCGroupMemoryLimitForHeap", "-Djava.security.egd=file:/dev/./urandom","-jar","/app.jar"]
+    entrypoint: ["./dockerize","-wait=tcp://discovery-server:8761","-timeout=60s","--","java", "org.springframework.boot.loader.JarLauncher"]
     ports:
     - 8081:8081
 
@@ -36,7 +36,7 @@ services:
     depends_on:
      - config-server
      - discovery-server
-    entrypoint: ["./dockerize","-wait=tcp://discovery-server:8761","-timeout=60s","--","java", "-XX:+UnlockExperimentalVMOptions", "-XX:+UseCGroupMemoryLimitForHeap", "-Djava.security.egd=file:/dev/./urandom","-jar","/app.jar"]
+    entrypoint: ["./dockerize","-wait=tcp://discovery-server:8761","-timeout=60s","--","java", "org.springframework.boot.loader.JarLauncher"]
     ports:
      - 8082:8082
 
@@ -47,7 +47,7 @@ services:
     depends_on:
      - config-server
      - discovery-server
-    entrypoint: ["./dockerize","-wait=tcp://discovery-server:8761","-timeout=60s","--","java", "-XX:+UnlockExperimentalVMOptions", "-XX:+UseCGroupMemoryLimitForHeap", "-Djava.security.egd=file:/dev/./urandom","-jar","/app.jar"]
+    entrypoint: ["./dockerize","-wait=tcp://discovery-server:8761","-timeout=60s","--","java", "org.springframework.boot.loader.JarLauncher"]
     ports:
      - 8083:8083
 
@@ -58,7 +58,7 @@ services:
     depends_on:
      - config-server
      - discovery-server
-    entrypoint: ["./dockerize","-wait=tcp://discovery-server:8761","-timeout=60s","--","java", "-XX:+UnlockExperimentalVMOptions", "-XX:+UseCGroupMemoryLimitForHeap", "-Djava.security.egd=file:/dev/./urandom","-jar","/app.jar"]
+    entrypoint: ["./dockerize","-wait=tcp://discovery-server:8761","-timeout=60s","--","java", "org.springframework.boot.loader.JarLauncher"]
     ports:
      - 8080:8080
 
@@ -78,7 +78,7 @@ services:
     depends_on:
      - config-server
      - discovery-server
-    entrypoint: ["./dockerize","-wait=tcp://discovery-server:8761","-timeout=60s","--","java", "-XX:+UnlockExperimentalVMOptions", "-XX:+UseCGroupMemoryLimitForHeap", "-Djava.security.egd=file:/dev/./urandom","-jar","/app.jar"]
+    entrypoint: ["./dockerize","-wait=tcp://discovery-server:8761","-timeout=60s","--","java", "org.springframework.boot.loader.JarLauncher"]
     ports:
      - 9090:9090
 

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -8,7 +8,6 @@ RUN java -Djarmode=layertools -jar application.jar extract
 ARG DOCKERIZE_VERSION
 RUN wget -O dockerize.tar.gz https://github.com/jwilder/dockerize/releases/download/${DOCKERIZE_VERSION}/dockerize-alpine-linux-amd64-${DOCKERIZE_VERSION}.tar.gz
 RUN tar xzf dockerize.tar.gz
-RUN rm dockerize.tar.gz
 RUN chmod +x dockerize
 
 

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -1,14 +1,8 @@
-FROM adoptopenjdk:11-jre-hotspot as builder
+FROM openjdk:11-jre as builder
 WORKDIR application
 ARG ARTIFACT_NAME
 COPY ${ARTIFACT_NAME}.jar application.jar
 RUN java -Djarmode=layertools -jar application.jar extract
-
-
-# wget is not installed on adoptopenjdk:11-jre-hotspot
-FROM openjdk:11-jre
-
-WORKDIR application
 
 # Download dockerize and cache that layer
 ARG DOCKERIZE_VERSION
@@ -16,6 +10,15 @@ RUN wget -O dockerize.tar.gz https://github.com/jwilder/dockerize/releases/downl
 RUN tar xzf dockerize.tar.gz
 RUN rm dockerize.tar.gz
 RUN chmod +x dockerize
+
+
+# wget is not installed on adoptopenjdk:11-jre-hotspot
+FROM adoptopenjdk:11-jre-hotspot
+
+WORKDIR application
+
+# Dockerize
+COPY --from=builder application/dockerize ./
 
 ARG EXPOSED_PORT
 EXPOSE ${EXPOSED_PORT}

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -1,19 +1,29 @@
-FROM openjdk:8-jre-alpine
-VOLUME /tmp
+FROM adoptopenjdk:11-jre-hotspot as builder
+WORKDIR application
+ARG ARTIFACT_NAME
+COPY ${ARTIFACT_NAME}.jar application.jar
+RUN java -Djarmode=layertools -jar application.jar extract
+
+
+# wget is not installed on adoptopenjdk:11-jre-hotspot
+FROM openjdk:11-jre
+
+WORKDIR application
 
 # Download dockerize and cache that layer
 ARG DOCKERIZE_VERSION
 RUN wget -O dockerize.tar.gz https://github.com/jwilder/dockerize/releases/download/${DOCKERIZE_VERSION}/dockerize-alpine-linux-amd64-${DOCKERIZE_VERSION}.tar.gz
 RUN tar xzf dockerize.tar.gz
+RUN rm dockerize.tar.gz
 RUN chmod +x dockerize
-
-# This is the first layer that won't be cached
-ARG ARTIFACT_NAME
-ADD ${ARTIFACT_NAME}.jar /app.jar
 
 ARG EXPOSED_PORT
 EXPOSE ${EXPOSED_PORT}
 
 ENV SPRING_PROFILES_ACTIVE docker
 
-ENTRYPOINT ["java", "-XX:+UnlockExperimentalVMOptions", "-XX:+UseCGroupMemoryLimitForHeap", "-Djava.security.egd=file:/dev/./urandom","-jar","/app.jar"]
+COPY --from=builder application/dependencies/ ./
+COPY --from=builder application/spring-boot-loader/ ./
+COPY --from=builder application/snapshot-dependencies/ ./
+COPY --from=builder application/application/ ./
+ENTRYPOINT ["java", "org.springframework.boot.loader.JarLauncher"]

--- a/pom.xml
+++ b/pom.xml
@@ -72,6 +72,7 @@
         </dependencies>
     </dependencyManagement>
 
+
     <profiles>
         <profile>
             <id>springboot</id>
@@ -88,6 +89,10 @@
                         <artifactId>spring-boot-maven-plugin</artifactId>
                         <configuration>
                             <fork>true</fork>
+                            <!-- Layered jars optimizes Docker images -->
+                            <layers>
+                                <enabled>true</enabled>
+                            </layers>
                         </configuration>
                         <executions>
                             <execution>


### PR DESCRIPTION
The `spring-boot-maven-plugin` is configured to use the default layerd jars:
* `dependencies` for any dependency whose version does not contain SNAPSHOT.
* `spring-boot-loader` for the jar loader classes.
* `snapshot-dependencies` for any dependency whose version contains SNAPSHOT.
* `application` for application classes and resources.
More information on https://docs.spring.io/spring-boot/docs/current/maven-plugin/reference/html/

The `Dockerfile` has been updated with multi-staged build. The `builder` stage extract the JAR. Each directories belgons to a Docker layer
More information on https://spring.io/blog/2020/01/27/creating-docker-images-with-spring-boot-2-3-0-m1 