### PR TITLE
exclude junit-vintage-engine pom.xml

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -56,11 +56,11 @@
                 <version>${spring-boot.version}</version>
                 <scope>test</scope>
                 <exclusions>
-                    <exclusion>
-                    <groupId>junit</groupId>
-                    <artifactId>junit</artifactId>
-                    </exclusion>
-                </exclusions>
+			        <exclusion>
+			            <groupId>org.junit.vintage</groupId>
+			            <artifactId>junit-vintage-engine</artifactId>
+			        </exclusion>
+			    </exclusions>
             </dependency>
             <dependency>
                 <groupId>org.assertj</groupId>


### PR DESCRIPTION
This change fixes [issue#161](https://github.com/spring-petclinic/spring-petclinic-microservices/issues/161)