### PR TITLE
Fix docker build on BTRFS

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -14,7 +14,15 @@ EXPOSE ${EXPOSED_PORT}
 ENV SPRING_PROFILES_ACTIVE docker
 
 COPY --from=builder application/dependencies/ ./
+
+# fix for https://stackoverflow.com/questions/51115856/docker-failed-to-export-image-failed-to-create-image-failed-to-get-layer
+# (only last copy caused issue)
+# this seems to be triggered by using btrfs:
+# https://github.com/moby/moby/issues/36573
+RUN true
 COPY --from=builder application/spring-boot-loader/ ./
+RUN true
 COPY --from=builder application/snapshot-dependencies/ ./
+RUN true
 COPY --from=builder application/application/ ./
 ENTRYPOINT ["java", "org.springframework.boot.loader.launch.JarLauncher"]


### PR DESCRIPTION
when running `./mvnw clean install -PbuildDocker -Dmaven.test.skip=true` in my system which uses BTRFS and `Docker version 25.0.3, build 4debf411d1`, the docker build process thats happening under the hood fails with the root cause `layer does not exist`.

A bit of search led me to [this fix](https://stackoverflow.com/a/62409523), and with [this issue](https://github.com/moby/moby/issues/36573) i think I found the root reason why this fails just for me.

This MR changes the dockerfile so that it also works on my machine.