### PR TITLE
Huy/unit test/customer service

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -19,6 +19,7 @@ pipeline {
     stage("deploy") {
       steps {
         echo 'deploying the application...'
+        echo 'Deploying automation Deploy-staging'
       }
     }
   

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -1,0 +1,27 @@
+pipeline {
+  
+  agent any
+  
+  stages {
+  
+    stage("build") {
+      steps {
+        echo 'building the appliation...'
+      }
+    }
+
+    stage("test") {
+      steps {
+        echo 'testing the application...'
+      }
+    }
+
+    stage("deploy") {
+      steps {
+        echo 'deploying the application...'
+      }
+    }
+  
+  }
+
+}

--- a/spring-petclinic-customers-service/src/test/java/org/springframework/samples/petclinic/customers/web/OwnerResourceTest.java
+++ b/spring-petclinic-customers-service/src/test/java/org/springframework/samples/petclinic/customers/web/OwnerResourceTest.java
@@ -1,0 +1,148 @@
+package org.springframework.samples.petclinic.customers.web;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
+import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.http.MediaType;
+import org.springframework.samples.petclinic.customers.model.Owner;
+import org.springframework.samples.petclinic.customers.model.OwnerRepository;
+import org.springframework.samples.petclinic.customers.web.mapper.OwnerEntityMapper;
+import org.springframework.test.context.ActiveProfiles;
+import org.springframework.test.context.junit.jupiter.SpringExtension;
+import org.springframework.test.web.servlet.MockMvc;
+
+import java.util.Optional;
+
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.BDDMockito.given;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.*;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.content;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+@ExtendWith(SpringExtension.class)
+@WebMvcTest(OwnerResource.class)
+@ActiveProfiles("test")
+/**
+ * @author Hoang Tien Huy
+ */
+public class OwnerResourceTest {
+
+    @Autowired
+    MockMvc mvc;
+
+    @MockBean
+    OwnerRepository ownerRepository;
+
+    @MockBean
+    OwnerEntityMapper ownerEntityMapper;
+
+    //test get owner by id
+    @Test
+    void findOwner_whenOwnerExists_returnOwner() throws Exception {
+        Owner owner = setupOwner();
+        given(ownerRepository.findById(1)).willReturn(Optional.of(owner));
+
+        mvc.perform(get("/owners/1"))
+            .andExpect(status().isOk())
+            .andExpect(jsonPath("$.id").value(owner.getId()))
+            .andExpect(jsonPath("$.firstName").value(owner.getFirstName()));
+    }
+    @Test
+    void findOwner_whenOwnerNotFound_returnEmpty() throws Exception {
+        given(ownerRepository.findById(99)).willReturn(Optional.empty());
+
+        mvc.perform(get("/owners/99"))
+            .andExpect(status().isOk())
+            .andExpect(content().string("null"));
+    }
+
+    //test create owner
+    @Test
+    void createOwner_whenValidRequest_returnCreatedOwner() throws Exception {
+        Owner owner = setupOwner();
+        int ownerId = 1;
+        OwnerRequest ownerRequest = setupOwnerRequest();
+        given(ownerEntityMapper.map(any(), any())).willReturn(owner);
+        given(ownerRepository.save(any())).willReturn(owner);
+
+        String json = new ObjectMapper().writeValueAsString(ownerRequest);
+
+        mvc.perform(post("/owners")
+                .contentType(MediaType.APPLICATION_JSON)
+                .content(json))
+            .andExpect(status().isCreated())
+            .andExpect(jsonPath("$.firstName").value(owner.getFirstName()))
+            .andExpect(jsonPath("$.lastName").value(owner.getLastName()))
+            .andExpect(jsonPath("$.address").value(owner.getAddress()))
+            .andExpect(jsonPath("$.city").value(owner.getCity()))
+            .andExpect(jsonPath("$.telephone").value(owner.getTelephone()));
+    }
+    @Test
+    void createOwner_whenInvalidRequest_returnBadRequest() throws Exception {
+        OwnerRequest ownerRequest = new OwnerRequest("", "", "", "", "");
+
+        mvc.perform(post("/owners")
+                .contentType(MediaType.APPLICATION_JSON)
+                .content(new ObjectMapper().writeValueAsString(ownerRequest)))
+            .andExpect(status().isBadRequest());
+    }
+
+    //test update owner
+    @Test
+    void updateOwner_whenValidRequest_returnUpdatedOwner() throws Exception {
+        Owner owner = setupOwner();
+        int ownerId = 1;
+        OwnerRequest ownerRequest = setupOwnerRequest();
+        given(ownerRepository.findById(ownerId)).willReturn(Optional.of(owner));
+        given(ownerEntityMapper.map(any(), any())).willReturn(owner);
+        given(ownerRepository.save(any())).willReturn(owner);
+
+        String json = new ObjectMapper().writeValueAsString(ownerRequest);
+
+        mvc.perform(put("/owners/{ownerId}", ownerId)
+                .contentType(MediaType.APPLICATION_JSON)
+                .content(json))
+            .andExpect(status().isNoContent());
+    }
+    @Test
+    void updateOwner_whenOwnerNotFound_returnNotFound() throws Exception {
+        int ownerId = 99;
+        OwnerRequest ownerRequest = setupOwnerRequest();
+        given(ownerRepository.findById(ownerId)).willReturn(Optional.empty());
+
+        mvc.perform(put("/owners/{ownerId}", ownerId)
+                .contentType(MediaType.APPLICATION_JSON)
+                .content(new ObjectMapper().writeValueAsString(ownerRequest)))
+            .andExpect(status().isNotFound());
+    }
+    @Test
+    void updateOwner_whenInvalidRequest_returnBadRequest() throws Exception {
+        int ownerId = 1;
+        OwnerRequest ownerRequest = new OwnerRequest("", "", "", "", "");
+
+        mvc.perform(put("/owners/{ownerId}", ownerId)
+                .contentType(MediaType.APPLICATION_JSON)
+                .content(new ObjectMapper().writeValueAsString(ownerRequest)))
+            .andExpect(status().isBadRequest());
+    }
+
+    private Owner setupOwner() {
+        Owner owner = new Owner();
+        owner.setFirstName("John");
+        owner.setLastName("Doe");
+        owner.setAddress("123 Main St");
+        owner.setCity("New York");
+        owner.setTelephone("123456237890");
+        return owner;
+    }
+
+    private OwnerRequest setupOwnerRequest() {
+        return new OwnerRequest("John", "Doe", "123 Main St",
+            "New York","123345627890");
+    }
+}

--- a/spring-petclinic-customers-service/src/test/java/org/springframework/samples/petclinic/customers/web/PetResourceTest.java
+++ b/spring-petclinic-customers-service/src/test/java/org/springframework/samples/petclinic/customers/web/PetResourceTest.java
@@ -1,7 +1,11 @@
 package org.springframework.samples.petclinic.customers.web;
 
+import java.text.ParseException;
+import java.text.SimpleDateFormat;
+import java.util.Date;
 import java.util.Optional;
 
+import com.fasterxml.jackson.databind.ObjectMapper;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -18,8 +22,9 @@ import org.springframework.test.context.junit.jupiter.SpringExtension;
 import org.springframework.test.web.servlet.MockMvc;
 
 
+import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.BDDMockito.given;
-import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.*;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.content;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
@@ -57,21 +62,93 @@ class PetResourceTest {
             .andExpect(jsonPath("$.type.id").value(6));
     }
 
+    //test for post method
+    @Test
+    void createPet_whenOwnerDoesNotExist_returnNotFound() throws Exception {
+        int ownerId = 99;
+
+        given(ownerRepository.findById(ownerId)).willReturn(Optional.empty());
+
+        PetRequest petRequest = setupPetRequest();
+
+        String json = new ObjectMapper().writeValueAsString(petRequest);
+
+        mvc.perform(post("/owners/{ownerId}/pets", ownerId)
+                .contentType(MediaType.APPLICATION_JSON)
+                .content(json))
+            .andExpect(status().isNotFound());
+    }
+    @Test
+    void createPet_whenOwnerExist_returnCreatedPet() throws Exception {
+
+        int ownerId = 2;
+        Owner owner = setupOwner();
+        PetRequest petRequest = setupPetRequest();
+        PetType type = setupPetType();
+        Pet savePet = setupPet();
+
+        given(ownerRepository.findById(ownerId)).willReturn(Optional.of(owner));
+        given(petRepository.findPetTypeById(petRequest.typeId())).willReturn(Optional.of(type));
+        given(petRepository.findById(2)).willReturn(Optional.of(savePet));
+        given(petRepository.save(any(Pet.class))).willReturn(savePet);
+
+
+        String json = new ObjectMapper().writeValueAsString(petRequest);
+
+        mvc.perform(post("/owners/{ownerId}/pets", ownerId)
+                .contentType(MediaType.APPLICATION_JSON)
+                .content(json))
+            .andExpect(status().isCreated())
+            .andExpect(jsonPath("$.id").value(2))
+            .andExpect(jsonPath("$.name").value("Basil"))
+            .andExpect(jsonPath("$.type.id").value(2));
+    }
+    @Test
+    void createPet_whenPetRequestIsNull_returnBadRequest() throws Exception {
+        int ownerId = 2;
+
+        given(ownerRepository.findById(ownerId)).willReturn(Optional.of(setupOwner()));
+
+        mvc.perform(post("/owners/{ownerId}/pets", ownerId)
+                .contentType(MediaType.APPLICATION_JSON)
+                .content(""))
+            .andExpect(status().isBadRequest());
+    }
+
+
     private Pet setupPet() {
-        Owner owner = new Owner();
-        owner.setFirstName("George");
-        owner.setLastName("Bush");
+        Owner owner = setupOwner();
 
         Pet pet = new Pet();
 
         pet.setName("Basil");
         pet.setId(2);
 
-        PetType petType = new PetType();
-        petType.setId(6);
+        PetType petType = setupPetType();
         pet.setType(petType);
 
         owner.addPet(pet);
         return pet;
+    }
+
+    private Owner setupOwner() {
+        Owner owner = new Owner();
+        owner.setFirstName("George");
+        owner.setLastName("Bush");
+        return owner;
+    }
+
+    private PetRequest setupPetRequest() throws ParseException {
+        String dateString = "2025/04/10";
+        SimpleDateFormat formatter = new SimpleDateFormat("yyyy/MM/dd");
+        Date birthDate = formatter.parse(dateString);
+        return new PetRequest(2, birthDate, "Basil", 2);
+    }
+
+    private PetType setupPetType() {
+        PetType petType = new PetType();
+        petType.setId(2);
+        petType.setName("dog");
+        return petType;
     }
 }


### PR DESCRIPTION
This pull request includes the addition of new test cases for the `OwnerResource` and `PetResource` classes in the `spring-petclinic-customers-service` module.

### Unit Tests for `OwnerResource`:
* Added a new test class `OwnerResourceTest` with tests for the `findOwner`, `createOwner`, and `updateOwner` methods, including various scenarios such as valid requests, invalid requests, and handling non-existent owners.

### Unit Tests for `PetResource`:
* Enhanced the `PetResourceTest` class by adding tests for the `createPet` method, covering scenarios like non-existent owners, valid pet creation, and invalid requests.
* Added necessary imports and setup methods (`setupOwner`, `setupPetRequest`, `setupPetType`) to support the new tests in `PetResourceTest`. 