### PR TITLE
Remove the temporary JAVA_OPTS environment variable for tracing-server

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -120,9 +120,6 @@ services:
       resources:
         limits:
           memory: 512M
-    environment:
-    # Waiting for https://github.com/openzipkin/zipkin/issues/3786
-    - JAVA_OPTS=-XX:UseSVE=0
     ports:
      - 9411:9411
 


### PR DESCRIPTION
Should fix https://github.com/spring-petclinic/spring-petclinic-microservices/issues/363