### PR TITLE
fix: no context propagation and zipkin spans fixed

### DIFF
--- a/spring-petclinic-api-gateway/src/main/resources/application.yml
+++ b/spring-petclinic-api-gateway/src/main/resources/application.yml
@@ -43,11 +43,11 @@ spring:
               filters:
                 - StripPrefix=2
                 - CircuitBreaker=name=genaiCircuitBreaker,fallbackUri=/fallback
-  reactor:
-    context-propagation: auto
 ---
 spring:
   config:
     activate:
       on-profile: docker
     import: configserver:http://config-server:8888
+reactor:
+  context-propagation: auto


### PR DESCRIPTION
move reactor.context-propagation to docker profile (to match PR: spring-petclinic/spring-petclinic-microservices-config#34 of the config repo) to fix context propagation issue which was causing incomplete spans in zipkin dashboard.