### PR TITLE
feat(issue-3): Config Server and Discovery Server K8s deployment

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -21,3 +21,7 @@ target/
 generated/
 
 **/.DS_Store
+.terraform/
+*.tfstate
+*.tfstate.backup
+.terraform.lock.hcl

--- a/bootstrap/.terraform.lock.hcl
+++ b/bootstrap/.terraform.lock.hcl
@@ -1,0 +1,25 @@
+# This file is maintained automatically by "terraform init".
+# Manual edits may be lost in future updates.
+
+provider "registry.terraform.io/hashicorp/aws" {
+  version     = "5.100.0"
+  constraints = "~> 5.0"
+  hashes = [
+    "h1:edXOJWE4ORX8Fm+dpVpICzMZJat4AX0VRCAy/xkcOc0=",
+    "zh:054b8dd49f0549c9a7cc27d159e45327b7b65cf404da5e5a20da154b90b8a644",
+    "zh:0b97bf8d5e03d15d83cc40b0530a1f84b459354939ba6f135a0086c20ebbe6b2",
+    "zh:1589a2266af699cbd5d80737a0fe02e54ec9cf2ca54e7e00ac51c7359056f274",
+    "zh:6330766f1d85f01ae6ea90d1b214b8b74cc8c1badc4696b165b36ddd4cc15f7b",
+    "zh:7c8c2e30d8e55291b86fcb64bdf6c25489d538688545eb48fd74ad622e5d3862",
+    "zh:99b1003bd9bd32ee323544da897148f46a527f622dc3971af63ea3e251596342",
+    "zh:9b12af85486a96aedd8d7984b0ff811a4b42e3d88dad1a3fb4c0b580d04fa425",
+    "zh:9f8b909d3ec50ade83c8062290378b1ec553edef6a447c56dadc01a99f4eaa93",
+    "zh:aaef921ff9aabaf8b1869a86d692ebd24fbd4e12c21205034bb679b9caf883a2",
+    "zh:ac882313207aba00dd5a76dbd572a0ddc818bb9cbf5c9d61b28fe30efaec951e",
+    "zh:bb64e8aff37becab373a1a0cc1080990785304141af42ed6aa3dd4913b000421",
+    "zh:dfe495f6621df5540d9c92ad40b8067376350b005c637ea6efac5dc15028add4",
+    "zh:f0ddf0eaf052766cfe09dea8200a946519f653c384ab4336e2a4a64fdd6310e9",
+    "zh:f1b7e684f4c7ae1eed272b6de7d2049bb87a0275cb04dbb7cda6636f600699c9",
+    "zh:ff461571e3f233699bf690db319dfe46aec75e58726636a0d97dd9ac6e32fb70",
+  ]
+}

--- a/bootstrap/main.tf
+++ b/bootstrap/main.tf
@@ -1,0 +1,53 @@
+resource "aws_s3_bucket" "terraform_state" {
+  bucket = var.terraform_state_bucket
+
+  tags = {
+    Name        = "petclinic-tfstate"
+    Environment = "dev"
+    Project     = "spring-petclinic"
+  }
+}
+
+resource "aws_s3_bucket_versioning" "terraform_state" {
+  bucket = aws_s3_bucket.terraform_state.id
+
+  versioning_configuration {
+    status = "Enabled"
+  }
+}
+
+resource "aws_s3_bucket_server_side_encryption_configuration" "terraform_state" {
+  bucket = aws_s3_bucket.terraform_state.id
+
+  rule {
+    apply_server_side_encryption_by_default {
+      sse_algorithm = "AES256"
+    }
+  }
+}
+
+resource "aws_s3_bucket_public_access_block" "terraform_state" {
+  bucket = aws_s3_bucket.terraform_state.id
+
+  block_public_acls       = true
+  block_public_policy     = true
+  ignore_public_acls      = true
+  restrict_public_buckets = true
+}
+
+resource "aws_dynamodb_table" "terraform_locks" {
+  name         = var.terraform_lock_table
+  billing_mode = "PAY_PER_REQUEST"
+  hash_key     = "LockID"
+
+  attribute {
+    name = "LockID"
+    type = "S"
+  }
+
+  tags = {
+    Name        = "petclinic-terraform-locks"
+    Environment = "dev"
+    Project     = "spring-petclinic"
+  }
+}

--- a/bootstrap/provider.tf
+++ b/bootstrap/provider.tf
@@ -1,0 +1,3 @@
+provider "aws" {
+  region = var.aws_region
+}

--- a/bootstrap/terraform.tfstate
+++ b/bootstrap/terraform.tfstate
@@ -1,0 +1,241 @@
+{
+  "version": 4,
+  "terraform_version": "1.6.3",
+  "serial": 6,
+  "lineage": "d7fa2514-9380-84aa-4c3c-b3eaa1ba26f9",
+  "outputs": {},
+  "resources": [
+    {
+      "mode": "managed",
+      "type": "aws_dynamodb_table",
+      "name": "terraform_locks",
+      "provider": "provider[\"registry.terraform.io/hashicorp/aws\"]",
+      "instances": [
+        {
+          "schema_version": 1,
+          "attributes": {
+            "arn": "arn:aws:dynamodb:us-east-1:989800606347:table/petclinic-terraform-locks",
+            "attribute": [
+              {
+                "name": "LockID",
+                "type": "S"
+              }
+            ],
+            "billing_mode": "PAY_PER_REQUEST",
+            "deletion_protection_enabled": false,
+            "global_secondary_index": [],
+            "hash_key": "LockID",
+            "id": "petclinic-terraform-locks",
+            "import_table": [],
+            "local_secondary_index": [],
+            "name": "petclinic-terraform-locks",
+            "on_demand_throughput": [],
+            "point_in_time_recovery": [
+              {
+                "enabled": false,
+                "recovery_period_in_days": 0
+              }
+            ],
+            "range_key": null,
+            "read_capacity": 0,
+            "replica": [],
+            "restore_date_time": null,
+            "restore_source_name": null,
+            "restore_source_table_arn": null,
+            "restore_to_latest_time": null,
+            "server_side_encryption": [],
+            "stream_arn": "",
+            "stream_enabled": false,
+            "stream_label": "",
+            "stream_view_type": "",
+            "table_class": "STANDARD",
+            "tags": {
+              "Environment": "dev",
+              "Name": "petclinic-terraform-locks",
+              "Project": "spring-petclinic"
+            },
+            "tags_all": {
+              "Environment": "dev",
+              "Name": "petclinic-terraform-locks",
+              "Project": "spring-petclinic"
+            },
+            "timeouts": null,
+            "ttl": [
+              {
+                "attribute_name": "",
+                "enabled": false
+              }
+            ],
+            "write_capacity": 0
+          },
+          "sensitive_attributes": [],
+          "private": "eyJlMmJmYjczMC1lY2FhLTExZTYtOGY4OC0zNDM2M2JjN2M0YzAiOnsiY3JlYXRlIjoxODAwMDAwMDAwMDAwLCJkZWxldGUiOjYwMDAwMDAwMDAwMCwidXBkYXRlIjozNjAwMDAwMDAwMDAwfSwic2NoZW1hX3ZlcnNpb24iOiIxIn0="
+        }
+      ]
+    },
+    {
+      "mode": "managed",
+      "type": "aws_s3_bucket",
+      "name": "terraform_state",
+      "provider": "provider[\"registry.terraform.io/hashicorp/aws\"]",
+      "instances": [
+        {
+          "schema_version": 0,
+          "attributes": {
+            "acceleration_status": "",
+            "acl": null,
+            "arn": "arn:aws:s3:::petclinic-tfstate-989800606347",
+            "bucket": "petclinic-tfstate-989800606347",
+            "bucket_domain_name": "petclinic-tfstate-989800606347.s3.amazonaws.com",
+            "bucket_prefix": "",
+            "bucket_regional_domain_name": "petclinic-tfstate-989800606347.s3.us-east-1.amazonaws.com",
+            "cors_rule": [],
+            "force_destroy": false,
+            "grant": [
+              {
+                "id": "c6e6a95226ad4b4b431d6c587ac6c99aa3d0976467aaff452842aa373ce69adc",
+                "permissions": [
+                  "FULL_CONTROL"
+                ],
+                "type": "CanonicalUser",
+                "uri": ""
+              }
+            ],
+            "hosted_zone_id": "Z3AQBSTGFYJSTF",
+            "id": "petclinic-tfstate-989800606347",
+            "lifecycle_rule": [],
+            "logging": [],
+            "object_lock_configuration": [],
+            "object_lock_enabled": false,
+            "policy": "",
+            "region": "us-east-1",
+            "replication_configuration": [],
+            "request_payer": "BucketOwner",
+            "server_side_encryption_configuration": [
+              {
+                "rule": [
+                  {
+                    "apply_server_side_encryption_by_default": [
+                      {
+                        "kms_master_key_id": "",
+                        "sse_algorithm": "AES256"
+                      }
+                    ],
+                    "bucket_key_enabled": false
+                  }
+                ]
+              }
+            ],
+            "tags": {
+              "Environment": "dev",
+              "Name": "petclinic-tfstate",
+              "Project": "spring-petclinic"
+            },
+            "tags_all": {
+              "Environment": "dev",
+              "Name": "petclinic-tfstate",
+              "Project": "spring-petclinic"
+            },
+            "timeouts": null,
+            "versioning": [
+              {
+                "enabled": false,
+                "mfa_delete": false
+              }
+            ],
+            "website": [],
+            "website_domain": null,
+            "website_endpoint": null
+          },
+          "sensitive_attributes": [],
+          "private": "eyJlMmJmYjczMC1lY2FhLTExZTYtOGY4OC0zNDM2M2JjN2M0YzAiOnsiY3JlYXRlIjoxMjAwMDAwMDAwMDAwLCJkZWxldGUiOjM2MDAwMDAwMDAwMDAsInJlYWQiOjEyMDAwMDAwMDAwMDAsInVwZGF0ZSI6MTIwMDAwMDAwMDAwMH19"
+        }
+      ]
+    },
+    {
+      "mode": "managed",
+      "type": "aws_s3_bucket_public_access_block",
+      "name": "terraform_state",
+      "provider": "provider[\"registry.terraform.io/hashicorp/aws\"]",
+      "instances": [
+        {
+          "schema_version": 0,
+          "attributes": {
+            "block_public_acls": true,
+            "block_public_policy": true,
+            "bucket": "petclinic-tfstate-989800606347",
+            "id": "petclinic-tfstate-989800606347",
+            "ignore_public_acls": true,
+            "restrict_public_buckets": true
+          },
+          "sensitive_attributes": [],
+          "private": "bnVsbA==",
+          "dependencies": [
+            "aws_s3_bucket.terraform_state"
+          ]
+        }
+      ]
+    },
+    {
+      "mode": "managed",
+      "type": "aws_s3_bucket_server_side_encryption_configuration",
+      "name": "terraform_state",
+      "provider": "provider[\"registry.terraform.io/hashicorp/aws\"]",
+      "instances": [
+        {
+          "schema_version": 0,
+          "attributes": {
+            "bucket": "petclinic-tfstate-989800606347",
+            "expected_bucket_owner": "",
+            "id": "petclinic-tfstate-989800606347",
+            "rule": [
+              {
+                "apply_server_side_encryption_by_default": [
+                  {
+                    "kms_master_key_id": "",
+                    "sse_algorithm": "AES256"
+                  }
+                ],
+                "bucket_key_enabled": null
+              }
+            ]
+          },
+          "sensitive_attributes": [],
+          "private": "bnVsbA==",
+          "dependencies": [
+            "aws_s3_bucket.terraform_state"
+          ]
+        }
+      ]
+    },
+    {
+      "mode": "managed",
+      "type": "aws_s3_bucket_versioning",
+      "name": "terraform_state",
+      "provider": "provider[\"registry.terraform.io/hashicorp/aws\"]",
+      "instances": [
+        {
+          "schema_version": 0,
+          "attributes": {
+            "bucket": "petclinic-tfstate-989800606347",
+            "expected_bucket_owner": "",
+            "id": "petclinic-tfstate-989800606347",
+            "mfa": null,
+            "versioning_configuration": [
+              {
+                "mfa_delete": "",
+                "status": "Enabled"
+              }
+            ]
+          },
+          "sensitive_attributes": [],
+          "private": "bnVsbA==",
+          "dependencies": [
+            "aws_s3_bucket.terraform_state"
+          ]
+        }
+      ]
+    }
+  ],
+  "check_results": null
+}

--- a/bootstrap/terraform.tfvars
+++ b/bootstrap/terraform.tfvars
@@ -1,0 +1,4 @@
+aws_region = "us-east-1"
+
+terraform_state_bucket = "petclinic-tfstate-989800606347"
+terraform_lock_table   = "petclinic-terraform-locks"

--- a/bootstrap/variables.tf
+++ b/bootstrap/variables.tf
@@ -1,0 +1,11 @@
+variable "aws_region" {
+  type = string
+}
+
+variable "terraform_state_bucket" {
+  type = string
+}
+
+variable "terraform_lock_table" {
+  type = string
+}

--- a/bootstrap/versions.tf
+++ b/bootstrap/versions.tf
@@ -1,0 +1,10 @@
+terraform {
+  required_version = ">= 1.6.0"
+
+  required_providers {
+    aws = {
+      source  = "hashicorp/aws"
+      version = "~> 5.0"
+    }
+  }
+}

--- a/infra/.terraform.lock.hcl
+++ b/infra/.terraform.lock.hcl
@@ -1,0 +1,25 @@
+# This file is maintained automatically by "terraform init".
+# Manual edits may be lost in future updates.
+
+provider "registry.terraform.io/hashicorp/aws" {
+  version     = "5.100.0"
+  constraints = "~> 5.0"
+  hashes = [
+    "h1:edXOJWE4ORX8Fm+dpVpICzMZJat4AX0VRCAy/xkcOc0=",
+    "zh:054b8dd49f0549c9a7cc27d159e45327b7b65cf404da5e5a20da154b90b8a644",
+    "zh:0b97bf8d5e03d15d83cc40b0530a1f84b459354939ba6f135a0086c20ebbe6b2",
+    "zh:1589a2266af699cbd5d80737a0fe02e54ec9cf2ca54e7e00ac51c7359056f274",
+    "zh:6330766f1d85f01ae6ea90d1b214b8b74cc8c1badc4696b165b36ddd4cc15f7b",
+    "zh:7c8c2e30d8e55291b86fcb64bdf6c25489d538688545eb48fd74ad622e5d3862",
+    "zh:99b1003bd9bd32ee323544da897148f46a527f622dc3971af63ea3e251596342",
+    "zh:9b12af85486a96aedd8d7984b0ff811a4b42e3d88dad1a3fb4c0b580d04fa425",
+    "zh:9f8b909d3ec50ade83c8062290378b1ec553edef6a447c56dadc01a99f4eaa93",
+    "zh:aaef921ff9aabaf8b1869a86d692ebd24fbd4e12c21205034bb679b9caf883a2",
+    "zh:ac882313207aba00dd5a76dbd572a0ddc818bb9cbf5c9d61b28fe30efaec951e",
+    "zh:bb64e8aff37becab373a1a0cc1080990785304141af42ed6aa3dd4913b000421",
+    "zh:dfe495f6621df5540d9c92ad40b8067376350b005c637ea6efac5dc15028add4",
+    "zh:f0ddf0eaf052766cfe09dea8200a946519f653c384ab4336e2a4a64fdd6310e9",
+    "zh:f1b7e684f4c7ae1eed272b6de7d2049bb87a0275cb04dbb7cda6636f600699c9",
+    "zh:ff461571e3f233699bf690db319dfe46aec75e58726636a0d97dd9ac6e32fb70",
+  ]
+}

--- a/infra/iam_policy.json
+++ b/infra/iam_policy.json
@@ -1,0 +1,251 @@
+{
+    "Version": "2012-10-17",
+    "Statement": [
+        {
+            "Effect": "Allow",
+            "Action": [
+                "iam:CreateServiceLinkedRole"
+            ],
+            "Resource": "*",
+            "Condition": {
+                "StringEquals": {
+                    "iam:AWSServiceName": "elasticloadbalancing.amazonaws.com"
+                }
+            }
+        },
+        {
+            "Effect": "Allow",
+            "Action": [
+                "ec2:DescribeAccountAttributes",
+                "ec2:DescribeAddresses",
+                "ec2:DescribeAvailabilityZones",
+                "ec2:DescribeInternetGateways",
+                "ec2:DescribeVpcs",
+                "ec2:DescribeVpcPeeringConnections",
+                "ec2:DescribeSubnets",
+                "ec2:DescribeSecurityGroups",
+                "ec2:DescribeInstances",
+                "ec2:DescribeNetworkInterfaces",
+                "ec2:DescribeTags",
+                "ec2:GetCoipPoolUsage",
+                "ec2:DescribeCoipPools",
+                "ec2:GetSecurityGroupsForVpc",
+                "ec2:DescribeIpamPools",
+                "ec2:DescribeRouteTables",
+                "elasticloadbalancing:DescribeLoadBalancers",
+                "elasticloadbalancing:DescribeLoadBalancerAttributes",
+                "elasticloadbalancing:DescribeListeners",
+                "elasticloadbalancing:DescribeListenerCertificates",
+                "elasticloadbalancing:DescribeSSLPolicies",
+                "elasticloadbalancing:DescribeRules",
+                "elasticloadbalancing:DescribeTargetGroups",
+                "elasticloadbalancing:DescribeTargetGroupAttributes",
+                "elasticloadbalancing:DescribeTargetHealth",
+                "elasticloadbalancing:DescribeTags",
+                "elasticloadbalancing:DescribeTrustStores",
+                "elasticloadbalancing:DescribeListenerAttributes",
+                "elasticloadbalancing:DescribeCapacityReservation"
+            ],
+            "Resource": "*"
+        },
+        {
+            "Effect": "Allow",
+            "Action": [
+                "cognito-idp:DescribeUserPoolClient",
+                "acm:ListCertificates",
+                "acm:DescribeCertificate",
+                "iam:ListServerCertificates",
+                "iam:GetServerCertificate",
+                "waf-regional:GetWebACL",
+                "waf-regional:GetWebACLForResource",
+                "waf-regional:AssociateWebACL",
+                "waf-regional:DisassociateWebACL",
+                "wafv2:GetWebACL",
+                "wafv2:GetWebACLForResource",
+                "wafv2:AssociateWebACL",
+                "wafv2:DisassociateWebACL",
+                "shield:GetSubscriptionState",
+                "shield:DescribeProtection",
+                "shield:CreateProtection",
+                "shield:DeleteProtection"
+            ],
+            "Resource": "*"
+        },
+        {
+            "Effect": "Allow",
+            "Action": [
+                "ec2:AuthorizeSecurityGroupIngress",
+                "ec2:RevokeSecurityGroupIngress"
+            ],
+            "Resource": "*"
+        },
+        {
+            "Effect": "Allow",
+            "Action": [
+                "ec2:CreateSecurityGroup"
+            ],
+            "Resource": "*"
+        },
+        {
+            "Effect": "Allow",
+            "Action": [
+                "ec2:CreateTags"
+            ],
+            "Resource": "arn:aws:ec2:*:*:security-group/*",
+            "Condition": {
+                "StringEquals": {
+                    "ec2:CreateAction": "CreateSecurityGroup"
+                },
+                "Null": {
+                    "aws:RequestTag/elbv2.k8s.aws/cluster": "false"
+                }
+            }
+        },
+        {
+            "Effect": "Allow",
+            "Action": [
+                "ec2:CreateTags",
+                "ec2:DeleteTags"
+            ],
+            "Resource": "arn:aws:ec2:*:*:security-group/*",
+            "Condition": {
+                "Null": {
+                    "aws:RequestTag/elbv2.k8s.aws/cluster": "true",
+                    "aws:ResourceTag/elbv2.k8s.aws/cluster": "false"
+                }
+            }
+        },
+        {
+            "Effect": "Allow",
+            "Action": [
+                "ec2:AuthorizeSecurityGroupIngress",
+                "ec2:RevokeSecurityGroupIngress",
+                "ec2:DeleteSecurityGroup"
+            ],
+            "Resource": "*",
+            "Condition": {
+                "Null": {
+                    "aws:ResourceTag/elbv2.k8s.aws/cluster": "false"
+                }
+            }
+        },
+        {
+            "Effect": "Allow",
+            "Action": [
+                "elasticloadbalancing:CreateLoadBalancer",
+                "elasticloadbalancing:CreateTargetGroup"
+            ],
+            "Resource": "*",
+            "Condition": {
+                "Null": {
+                    "aws:RequestTag/elbv2.k8s.aws/cluster": "false"
+                }
+            }
+        },
+        {
+            "Effect": "Allow",
+            "Action": [
+                "elasticloadbalancing:CreateListener",
+                "elasticloadbalancing:DeleteListener",
+                "elasticloadbalancing:CreateRule",
+                "elasticloadbalancing:DeleteRule"
+            ],
+            "Resource": "*"
+        },
+        {
+            "Effect": "Allow",
+            "Action": [
+                "elasticloadbalancing:AddTags",
+                "elasticloadbalancing:RemoveTags"
+            ],
+            "Resource": [
+                "arn:aws:elasticloadbalancing:*:*:targetgroup/*/*",
+                "arn:aws:elasticloadbalancing:*:*:loadbalancer/net/*/*",
+                "arn:aws:elasticloadbalancing:*:*:loadbalancer/app/*/*"
+            ],
+            "Condition": {
+                "Null": {
+                    "aws:RequestTag/elbv2.k8s.aws/cluster": "true",
+                    "aws:ResourceTag/elbv2.k8s.aws/cluster": "false"
+                }
+            }
+        },
+        {
+            "Effect": "Allow",
+            "Action": [
+                "elasticloadbalancing:AddTags",
+                "elasticloadbalancing:RemoveTags"
+            ],
+            "Resource": [
+                "arn:aws:elasticloadbalancing:*:*:listener/net/*/*/*",
+                "arn:aws:elasticloadbalancing:*:*:listener/app/*/*/*",
+                "arn:aws:elasticloadbalancing:*:*:listener-rule/net/*/*/*",
+                "arn:aws:elasticloadbalancing:*:*:listener-rule/app/*/*/*"
+            ]
+        },
+        {
+            "Effect": "Allow",
+            "Action": [
+                "elasticloadbalancing:ModifyLoadBalancerAttributes",
+                "elasticloadbalancing:SetIpAddressType",
+                "elasticloadbalancing:SetSecurityGroups",
+                "elasticloadbalancing:SetSubnets",
+                "elasticloadbalancing:DeleteLoadBalancer",
+                "elasticloadbalancing:ModifyTargetGroup",
+                "elasticloadbalancing:ModifyTargetGroupAttributes",
+                "elasticloadbalancing:DeleteTargetGroup",
+                "elasticloadbalancing:ModifyListenerAttributes",
+                "elasticloadbalancing:ModifyCapacityReservation",
+                "elasticloadbalancing:ModifyIpPools"
+            ],
+            "Resource": "*",
+            "Condition": {
+                "Null": {
+                    "aws:ResourceTag/elbv2.k8s.aws/cluster": "false"
+                }
+            }
+        },
+        {
+            "Effect": "Allow",
+            "Action": [
+                "elasticloadbalancing:AddTags"
+            ],
+            "Resource": [
+                "arn:aws:elasticloadbalancing:*:*:targetgroup/*/*",
+                "arn:aws:elasticloadbalancing:*:*:loadbalancer/net/*/*",
+                "arn:aws:elasticloadbalancing:*:*:loadbalancer/app/*/*"
+            ],
+            "Condition": {
+                "StringEquals": {
+                    "elasticloadbalancing:CreateAction": [
+                        "CreateTargetGroup",
+                        "CreateLoadBalancer"
+                    ]
+                },
+                "Null": {
+                    "aws:RequestTag/elbv2.k8s.aws/cluster": "false"
+                }
+            }
+        },
+        {
+            "Effect": "Allow",
+            "Action": [
+                "elasticloadbalancing:RegisterTargets",
+                "elasticloadbalancing:DeregisterTargets"
+            ],
+            "Resource": "arn:aws:elasticloadbalancing:*:*:targetgroup/*/*"
+        },
+        {
+            "Effect": "Allow",
+            "Action": [
+                "elasticloadbalancing:SetWebAcl",
+                "elasticloadbalancing:ModifyListener",
+                "elasticloadbalancing:AddListenerCertificates",
+                "elasticloadbalancing:RemoveListenerCertificates",
+                "elasticloadbalancing:ModifyRule",
+                "elasticloadbalancing:SetRulePriorities"
+            ],
+            "Resource": "*"
+        }
+    ]
+}

--- a/infra/main.tf
+++ b/infra/main.tf
@@ -1,0 +1,40 @@
+module "vpc" {
+  source = "./modules/vpc"
+
+  vpc_cidr              = var.vpc_cidr
+  public_subnet_1_cidr  = var.public_subnet_1_cidr
+  public_subnet_2_cidr  = var.public_subnet_2_cidr
+  private_subnet_1_cidr = var.private_subnet_1_cidr
+  private_subnet_2_cidr = var.private_subnet_2_cidr
+}
+
+module "iam" {
+  source = "./modules/iam"
+
+  cluster_name = var.cluster_name
+}
+
+module "eks" {
+  source = "./modules/eks"
+
+  cluster_name       = var.cluster_name
+  cluster_role_arn   = module.iam.cluster_role_arn
+  node_role_arn      = module.iam.node_role_arn
+  private_subnet_ids = module.vpc.private_subnet_ids
+  desired_size       = var.desired_size
+  max_size           = var.max_size
+  min_size           = var.min_size
+}
+
+module "ecr" {
+  source = "./modules/ecr"
+
+  repository_names = [
+    "petclinic/spring-petclinic-config-server",
+    "petclinic/spring-petclinic-discovery-server",
+    "petclinic/spring-petclinic-customers-service",
+    "petclinic/spring-petclinic-vets-service",
+    "petclinic/spring-petclinic-visits-service",
+    "petclinic/spring-petclinic-api-gateway"
+  ]
+}

--- a/infra/modules/ecr/main.tf
+++ b/infra/modules/ecr/main.tf
@@ -1,0 +1,15 @@
+resource "aws_ecr_repository" "repositories" {
+  for_each = toset(var.repository_names)
+
+  name                 = each.value
+  image_tag_mutability = "MUTABLE"
+
+  image_scanning_configuration {
+    scan_on_push = true
+  }
+
+  tags = {
+    Project     = "spring-petclinic"
+    Environment = "dev"
+  }
+}

--- a/infra/modules/ecr/outputs.tf
+++ b/infra/modules/ecr/outputs.tf
@@ -1,0 +1,6 @@
+output "repository_urls" {
+  value = {
+    for repo_name, repo in aws_ecr_repository.repositories :
+    repo_name => repo.repository_url
+  }
+}

--- a/infra/modules/ecr/variables.tf
+++ b/infra/modules/ecr/variables.tf
@@ -1,0 +1,3 @@
+variable "repository_names" {
+  type = list(string)
+}

--- a/infra/modules/eks/.terraform.lock.hcl
+++ b/infra/modules/eks/.terraform.lock.hcl
@@ -1,0 +1,24 @@
+# This file is maintained automatically by "terraform init".
+# Manual edits may be lost in future updates.
+
+provider "registry.terraform.io/hashicorp/aws" {
+  version = "6.44.0"
+  hashes = [
+    "h1:ycsDqsaBxoZmyx9tZKxOFinhpb0oDAGryioYuF1LvfA=",
+    "zh:0462747d28f6dcd7b1b723bea9da1600526b7cdcf929ed4be54352d74b0746e6",
+    "zh:0c9b7e7b04050360f609ff5700d8a76227fb4ea84dac92b844d82a2013706705",
+    "zh:2877a6854edf237f9d6c66dc928294cbbcf29d3f52577fb8f232d0cfd11d5c0d",
+    "zh:3347b82e222bbfad326b79c408e53a9252b80c6c762f4dd4f4617583394f0a4e",
+    "zh:33997dbe611b5abf49c87a31f29d8f797c97421f67b71fec8aa688799511b758",
+    "zh:5d5c37375c5e776e6e8f95fb8cbd8009258618b9f51c55551a18adc09ef5814a",
+    "zh:67d6bd61c52ca5f4c37c96a76f6820c9f1902e4b83f89faddf9fd7f17ba0b160",
+    "zh:739588639fa30db7084d6939c2eb9b4dd2d7f58dbb5d5b3b2c4bda2a35dcf521",
+    "zh:9b12af85486a96aedd8d7984b0ff811a4b42e3d88dad1a3fb4c0b580d04fa425",
+    "zh:a953797142df4245bd8f456b9e78690f501a0fff2f58552db4eb2da409cd99e9",
+    "zh:aeb8d616dd34a9f1c5048ed4cdd6d7692db93cd33a468872618d4cd38c4784aa",
+    "zh:dc8420556aca50658247b097de6734259fc3a6012ff1cf96612fca10b3982f9d",
+    "zh:f9083d6d9fb9cbdcd91e38c92f96e67223ecc7ce6d0986bd5eb8e6d52e9aa02b",
+    "zh:f9418aa1e4d29f9026aa6f521e97d085e000902ea929debbbef61135185e3ad4",
+    "zh:fb2494a6c92118055cfb2c114a4fe5c750946a1b0d6be6bf02ab3e37a091fb8b",
+  ]
+}

--- a/infra/modules/eks/main.tf
+++ b/infra/modules/eks/main.tf
@@ -1,0 +1,49 @@
+resource "aws_eks_cluster" "main" {
+  name     = var.cluster_name
+  role_arn = var.cluster_role_arn
+
+  version = "1.31"
+
+  vpc_config {
+    subnet_ids              = var.private_subnet_ids
+    endpoint_private_access = true
+    endpoint_public_access  = true
+  }
+
+  tags = {
+    Name        = "petclinic-cluster"
+    Environment = "dev"
+    Project     = "spring-petclinic"
+  }
+}
+
+resource "aws_eks_node_group" "main" {
+  cluster_name    = aws_eks_cluster.main.name
+  node_group_name = "petclinic-workers"
+  node_role_arn   = var.node_role_arn
+
+  subnet_ids = var.private_subnet_ids
+
+  scaling_config {
+    desired_size = var.desired_size
+    max_size     = var.max_size
+    min_size     = var.min_size
+
+  }
+
+  disk_size = 20
+
+  instance_types = ["t3.medium"]
+
+  capacity_type = "ON_DEMAND"
+
+  depends_on = [
+    aws_eks_cluster.main
+  ]
+
+  tags = {
+    Name        = "petclinic-workers"
+    Environment = "dev"
+    Project     = "spring-petclinic"
+  }
+}

--- a/infra/modules/eks/outputs.tf
+++ b/infra/modules/eks/outputs.tf
@@ -1,0 +1,11 @@
+output "cluster_name" {
+  value = aws_eks_cluster.main.name
+}
+
+output "cluster_endpoint" {
+  value = aws_eks_cluster.main.endpoint
+}
+
+output "cluster_security_group_id" {
+  value = aws_eks_cluster.main.vpc_config[0].cluster_security_group_id
+}

--- a/infra/modules/eks/variables.tf
+++ b/infra/modules/eks/variables.tf
@@ -1,0 +1,27 @@
+variable "cluster_name" {
+  type = string
+}
+
+variable "cluster_role_arn" {
+  type = string
+}
+
+variable "node_role_arn" {
+  type = string
+}
+
+variable "private_subnet_ids" {
+  type = list(string)
+}
+
+variable "desired_size" {
+  type = number
+}
+
+variable "max_size" {
+  type = number
+}
+
+variable "min_size" {
+  type = number
+}

--- a/infra/modules/iam/main.tf
+++ b/infra/modules/iam/main.tf
@@ -1,0 +1,64 @@
+resource "aws_iam_role" "eks_cluster_role" {
+  name = "petclinic-eks-cluster-role"
+
+  # Terraform's "jsonencode" function converts a
+  # Terraform expression result to valid JSON syntax.
+  assume_role_policy = jsonencode({
+    Version = "2012-10-17"
+    Statement = [
+      {
+        Action = "sts:AssumeRole"
+        Effect = "Allow"
+        Sid    = ""
+        Principal = {
+          Service = "eks.amazonaws.com"
+        }
+      },
+    ]
+  })
+
+  tags = {
+  Name        = "petclinic-eks-cluster-role"
+  Environment = "dev"
+  Project     = "spring-petclinic"
+}
+}
+
+resource "aws_iam_role_policy_attachment" "eks_cluster_policy" {
+  role       = aws_iam_role.eks_cluster_role.name
+  policy_arn = "arn:aws:iam::aws:policy/AmazonEKSClusterPolicy"
+}
+resource "aws_iam_role" "eks_node_role" {
+  name = "petclinic-eks-node-role"
+
+  assume_role_policy = jsonencode({
+    Version = "2012-10-17"
+
+    Statement = [
+      {
+        Effect = "Allow"
+
+        Principal = {
+          Service = "ec2.amazonaws.com"
+        }
+
+        Action = "sts:AssumeRole"
+      }
+    ]
+  })
+}
+
+resource "aws_iam_role_policy_attachment" "worker_node_policy" {
+  policy_arn = "arn:aws:iam::aws:policy/AmazonEKSWorkerNodePolicy"
+  role       = aws_iam_role.eks_node_role.name
+}
+
+resource "aws_iam_role_policy_attachment" "cni_policy" {
+  policy_arn = "arn:aws:iam::aws:policy/AmazonEKS_CNI_Policy"
+  role       = aws_iam_role.eks_node_role.name
+}
+
+resource "aws_iam_role_policy_attachment" "ecr_read_policy" {
+  policy_arn = "arn:aws:iam::aws:policy/AmazonEC2ContainerRegistryReadOnly"
+  role       = aws_iam_role.eks_node_role.name
+}

--- a/infra/modules/iam/outputs.tf
+++ b/infra/modules/iam/outputs.tf
@@ -1,0 +1,7 @@
+output "cluster_role_arn" {
+  value = aws_iam_role.eks_cluster_role.arn
+}
+
+output "node_role_arn" {
+  value = aws_iam_role.eks_node_role.arn
+}

--- a/infra/modules/iam/variables.tf
+++ b/infra/modules/iam/variables.tf
@@ -1,0 +1,3 @@
+variable "cluster_name" {
+  type = string
+}

--- a/infra/modules/vpc/main.tf
+++ b/infra/modules/vpc/main.tf
@@ -1,0 +1,154 @@
+# Terraform configuration for AWS infrastructure of the Spring Pet Clinic application
+
+data "aws_availability_zones" "available" {
+  state = "available"
+}
+
+# Create a VPC for the Pet Clinic application
+resource "aws_vpc" "main" {
+  cidr_block = var.vpc_cidr
+  enable_dns_support   = true
+  enable_dns_hostnames = true
+
+  tags = {
+    Name = "petclinic-vpc"
+  }
+}
+
+# Create first public subnet in the VPC
+resource "aws_subnet" "public_1" {
+  vpc_id                  = aws_vpc.main.id
+  cidr_block              = var.public_subnet_1_cidr
+  map_public_ip_on_launch = true
+
+ availability_zone = data.aws_availability_zones.available.names[0]
+
+ tags = {
+   Name = "petclinic-public-1"
+    "kubernetes.io/role/elb" = "1"
+     "kubernetes.io/cluster/petclinic-cluster" = "shared"
+}
+  }
+
+
+# Create second public subnet in a different availability zone
+resource "aws_subnet" "public_2" {
+  vpc_id                  = aws_vpc.main.id
+  cidr_block              = var.public_subnet_2_cidr
+  map_public_ip_on_launch = true
+
+  availability_zone = data.aws_availability_zones.available.names[1]
+
+ tags = {
+  Name = "petclinic-public-2"
+  "kubernetes.io/role/elb" = "1"
+   "kubernetes.io/cluster/petclinic-cluster" = "shared"
+}
+}
+
+# Create first private subnet in the VPC
+resource "aws_subnet" "private_1" {
+  vpc_id            = aws_vpc.main.id
+  cidr_block        = var.private_subnet_1_cidr
+  availability_zone = data.aws_availability_zones.available.names[0]
+
+  tags = {
+   Name = "petclinic-private-1"
+    "kubernetes.io/role/internal-elb" = "1"
+     "kubernetes.io/cluster/petclinic-cluster" = "shared"
+}
+}
+
+# Create second private subnet in a different availability zone
+resource "aws_subnet" "private_2" {
+  vpc_id            = aws_vpc.main.id
+  cidr_block        = var.private_subnet_2_cidr
+  availability_zone = data.aws_availability_zones.available.names[1]
+
+  tags = {
+    Name = "petclinic-private-2"
+    "kubernetes.io/role/internal-elb" = "1"
+     "kubernetes.io/cluster/petclinic-cluster" = "shared"
+  }
+}
+  
+  # Create an Internet Gateway for the VPC
+  resource "aws_internet_gateway" "igw" {
+  vpc_id = aws_vpc.main.id
+
+}
+
+# Allocate an Elastic IP for the NAT Gateway
+resource "aws_eip" "nat_eip" {
+  domain = "vpc"
+}
+
+# Create a NAT Gateway in the first public subnet
+resource "aws_nat_gateway" "nat" {
+  allocation_id = aws_eip.nat_eip.id
+  subnet_id     = aws_subnet.public_1.id
+
+  depends_on = [
+    aws_internet_gateway.igw
+  ]
+
+  tags = {
+  Name = "petclinic-nat"
+}
+}
+
+# Public Route Table
+resource "aws_route_table" "public" {
+  vpc_id = aws_vpc.main.id
+
+  tags = {
+  Name = "petclinic-public-rt"
+}
+}
+
+# Route for public subnets to access the internet
+resource "aws_route" "public_internet_access" {
+  route_table_id         = aws_route_table.public.id
+  destination_cidr_block = "0.0.0.0/0"
+  gateway_id             = aws_internet_gateway.igw.id
+}
+
+# Associate public route table with first public subnet
+resource "aws_route_table_association" "public_1" {
+  subnet_id      = aws_subnet.public_1.id
+  route_table_id = aws_route_table.public.id
+}
+
+# Associate public route table with second public subnet
+resource "aws_route_table_association" "public_2" {
+  subnet_id      = aws_subnet.public_2.id
+  route_table_id = aws_route_table.public.id
+}
+
+# Private Route Table
+resource "aws_route_table" "private" {
+  vpc_id = aws_vpc.main.id
+    tags = {
+  Name = "petclinic-private-rt"
+}
+}
+
+# Route for private subnets to access the internet via NAT Gateway
+resource "aws_route" "private_nat_access" {
+  route_table_id         = aws_route_table.private.id
+  destination_cidr_block = "0.0.0.0/0"
+  nat_gateway_id         = aws_nat_gateway.nat.id
+}
+
+# Associate private route table with first private subnet
+resource "aws_route_table_association" "private_1" {
+  subnet_id      = aws_subnet.private_1.id
+  route_table_id = aws_route_table.private.id
+}
+
+# Associate private route table with second private subnet
+resource "aws_route_table_association" "private_2" {
+  subnet_id      = aws_subnet.private_2.id
+  route_table_id = aws_route_table.private.id
+}
+

--- a/infra/modules/vpc/outputs.tf
+++ b/infra/modules/vpc/outputs.tf
@@ -1,0 +1,17 @@
+output "vpc_id" {
+  value = aws_vpc.main.id
+}
+
+output "public_subnet_ids" {
+  value = [
+    aws_subnet.public_1.id,
+    aws_subnet.public_2.id
+  ]
+}
+
+output "private_subnet_ids" {
+  value = [
+    aws_subnet.private_1.id,
+    aws_subnet.private_2.id
+  ]
+}

--- a/infra/modules/vpc/variables.tf
+++ b/infra/modules/vpc/variables.tf
@@ -1,0 +1,20 @@
+
+variable "vpc_cidr" {
+  type = string
+}
+
+variable "public_subnet_1_cidr" {
+  type = string
+}
+
+variable "public_subnet_2_cidr" {
+  type = string
+}
+
+variable "private_subnet_1_cidr" {
+  type = string
+}
+
+variable "private_subnet_2_cidr" {
+  type = string
+}

--- a/infra/outputs.tf
+++ b/infra/outputs.tf
@@ -1,0 +1,15 @@
+output "cluster_name" {
+  value = module.eks.cluster_name
+}
+
+output "cluster_endpoint" {
+  value = module.eks.cluster_endpoint
+}
+
+output "vpc_id" {
+  value = module.vpc.vpc_id
+}
+
+output "ecr_repository_urls" {
+  value = module.ecr.repository_urls
+}

--- a/infra/provider.tf
+++ b/infra/provider.tf
@@ -1,0 +1,3 @@
+provider "aws" {
+  region = var.aws_region
+}

--- a/infra/terraform.tfvars
+++ b/infra/terraform.tfvars
@@ -1,0 +1,14 @@
+
+aws_region = "us-east-1"
+
+vpc_cidr              = "10.0.0.0/16"
+public_subnet_1_cidr  = "10.0.1.0/24"
+public_subnet_2_cidr  = "10.0.2.0/24"
+private_subnet_1_cidr = "10.0.3.0/24"
+private_subnet_2_cidr = "10.0.4.0/24"
+
+cluster_name = "petclinic-cluster"
+
+desired_size = 2
+max_size     = 4
+min_size     = 2

--- a/infra/trust-policy.json
+++ b/infra/trust-policy.json
@@ -1,0 +1,17 @@
+{
+  "Version": "2012-10-17",
+  "Statement": [
+    {
+      "Effect": "Allow",
+      "Principal": {
+        "Federated": "arn:aws:iam::989800606347:oidc-provider/oidc.eks.us-east-1.amazonaws.com/id/863D2070F7F17D0581A6AC7480EC71D9"
+      },
+      "Action": "sts:AssumeRoleWithWebIdentity",
+      "Condition": {
+        "StringEquals": {
+          "oidc.eks.us-east-1.amazonaws.com/id/863D2070F7F17D0581A6AC7480EC71D9:sub": "system:serviceaccount:kube-system:aws-load-balancer-controller"
+        }
+      }
+    }
+  ]
+}

--- a/infra/variables.tf
+++ b/infra/variables.tf
@@ -1,0 +1,27 @@
+
+variable "aws_region" {
+  description = "AWS deployment region"
+  type        = string
+}
+
+variable "vpc_cidr" {}
+variable "public_subnet_1_cidr" {}
+variable "public_subnet_2_cidr" {}
+variable "private_subnet_1_cidr" {}
+variable "private_subnet_2_cidr" {}
+
+variable "cluster_name" {
+  type = string
+}
+
+variable "desired_size" {
+  type = number
+}
+
+variable "max_size" {
+  type = number
+}
+
+variable "min_size" {
+  type = number
+}

--- a/infra/versions.tf
+++ b/infra/versions.tf
@@ -1,0 +1,18 @@
+terraform {
+  required_version = ">= 1.6.0"
+
+  backend "s3" {
+    bucket         = "petclinic-tfstate-989800606347"
+    key            = "infra/terraform.tfstate"
+    region         = "us-east-1"
+    dynamodb_table = "petclinic-terraform-locks"
+    encrypt        = true
+  }
+
+  required_providers {
+    aws = {
+      source  = "hashicorp/aws"
+      version = "~> 5.0"
+    }
+  }
+}

--- a/k8s/config-server/README.md
+++ b/k8s/config-server/README.md
@@ -1,0 +1,231 @@
+# Issue #3 — Config Server & Discovery Server (Eureka)
+**Branch:** `feature/issue-3-config-discovery`  
+**JIRA:** [Issue #3 - Configure service discovery and centralized config management](https://github.com/orgs/PetClinic-Project-Team/projects/1/views/2?pane=issue&itemId=184930136&issue=PetClinic-Project-Team%7Cspring-petclinic-microservices%7C3)  
+**Owner:** Harini (P4 — Config & Discovery Engineer)  
+**Status:** 🟡 In Progress — Pending AWS Account ID and ECR images from team
+
+---
+
+## What Is This Work?
+
+This folder contains the Kubernetes manifests to deploy two critical foundation
+services for the Spring PetClinic Microservices application on AWS EKS:
+
+### 1. Config Server (port 8888)
+The Config Server is the **first service that must start** in the entire application.
+It acts as a central configuration manager — every other microservice (customers,
+vets, visits, api-gateway, genai, admin) fetches its settings from here on startup.
+
+It reads all configuration files from this external GitHub repository:
+https://github.com/spring-petclinic/spring-petclinic-microservices-config
+
+Without Config Server running and healthy, NO other service can start.
+
+### 2. Discovery Server / Eureka (port 8761)
+The Discovery Server is the **second service that must start**.
+It is a Eureka service registry — every microservice registers itself here
+when it starts up, and the API Gateway uses it to route traffic dynamically.
+
+This is why the team decided to use Spring Boot native services instead of
+Kubernetes ConfigMap/DNS — the application is designed around this pattern.
+Replacing it would require significant code changes.
+
+The startup dependency chain is:
+Config Server → Discovery Server → All other services
+
+---
+
+## Files in This Folder
+k8s/
+├── config-server/
+│   ├── README.md          ← this file
+│   ├── deployment.yaml    ← K8s Deployment for config-server
+│   └── service.yaml       ← K8s ClusterIP Service on port 8888
+└── discovery-server/
+├── deployment.yaml    ← K8s Deployment for discovery-server
+└── service.yaml       ← K8s ClusterIP Service on port 8761
+
+---
+
+## What Has Been Done ✅
+
+- [x] Cloned team repo and created feature branch `feature/issue-3-config-discovery`
+- [x] Ran config-server and discovery-server locally using `docker compose up config-server discovery-server`
+- [x] Verified config-server health: `curl http://localhost:8888/actuator/health` → UP
+- [x] Verified config-server serves configs: `curl http://localhost:8888/discovery-server/docker` → configs returned from GitHub config repo
+- [x] Verified discovery-server health: `curl http://localhost:8761/actuator/health` → UP
+- [x] Verified Eureka dashboard at `http://localhost:8761` → loading correctly
+- [x] Created K8s folder structure: `k8s/config-server/` and `k8s/discovery-server/`
+- [x] Written `k8s/config-server/deployment.yaml` — Deployment with readiness + liveness probes
+- [x] Written `k8s/config-server/service.yaml` — ClusterIP Service on port 8888
+- [x] Written `k8s/discovery-server/deployment.yaml` — Deployment with initContainer that waits for config-server
+- [x] Written `k8s/discovery-server/service.yaml` — ClusterIP Service on port 8761
+
+---
+
+## What Is Pending ⏳
+
+### Needed from P2 (Infrastructure Engineer):
+
+**1. AWS Account ID**
+The ECR image URLs in both deployment files currently use a placeholder:
+<ACCOUNT_ID>.dkr.ecr.us-east-1.amazonaws.com/petclinic/spring-petclinic-config-server:latest
+<ACCOUNT_ID>.dkr.ecr.us-east-1.amazonaws.com/petclinic/spring-petclinic-discovery-server:latest
+Once you share the AWS Account ID, replace it like this:
+```bash
+sed -i 's/<ACCOUNT_ID>/YOUR_ACTUAL_ACCOUNT_ID/g' k8s/config-server/deployment.yaml
+sed -i 's/<ACCOUNT_ID>/YOUR_ACTUAL_ACCOUNT_ID/g' k8s/discovery-server/deployment.yaml
+```
+
+**2. Confirm EKS cluster is running:**
+```bash
+aws eks update-kubeconfig --name petclinic-cluster --region us-east-1
+kubectl get nodes
+```
+
+**3. Confirm namespace exists:**
+```bash
+kubectl get namespace spring-petclinic
+# If not created yet:
+kubectl create namespace spring-petclinic
+```
+
+### Needed from P3 (CI/CD Engineer):
+
+**1. Confirm Docker images are built and pushed to ECR:**
+```bash
+aws ecr list-images --repository-name petclinic/spring-petclinic-config-server --region us-east-1
+aws ecr list-images --repository-name petclinic/spring-petclinic-discovery-server --region us-east-1
+```
+
+**2. Confirm image tag being used** (latest or specific version)
+
+---
+
+## Why Is AWS Account ID Required?
+
+AWS ECR (Elastic Container Registry) is a private Docker image registry.
+The full image URL format is:
+<account-id>.dkr.ecr.<region>.amazonaws.com/<repo-name>:<tag>
+
+The Account ID is unique to your AWS account and is part of the ECR URL.
+Without it, Kubernetes cannot pull the Docker images and the pods will
+fail with `ImagePullBackOff` error.
+
+The ECR repositories are already created by P2 via Terraform:
+- `petclinic/spring-petclinic-config-server`
+- `petclinic/spring-petclinic-discovery-server`
+
+We just need the Account ID to complete the full URL.
+
+---
+
+## How to Test Once Details Are Available
+
+### Prerequisites
+- kubectl installed and configured
+- AWS CLI configured with access to the shared AWS account
+- EKS cluster running (`petclinic-cluster` in `us-east-1`)
+- ECR images pushed by P3
+
+### Step 1 — Get the branch
+```bash
+git fetch origin
+git checkout feature/issue-3-config-discovery
+```
+
+### Step 2 — Replace Account ID
+```bash
+# Replace <ACCOUNT_ID> with the real AWS account ID from P2
+sed -i 's/<ACCOUNT_ID>/123456789012/g' k8s/config-server/deployment.yaml
+sed -i 's/<ACCOUNT_ID>/123456789012/g' k8s/discovery-server/deployment.yaml
+```
+
+### Step 3 — Connect to EKS
+```bash
+aws eks update-kubeconfig --name petclinic-cluster --region us-east-1
+kubectl get nodes  # Should show nodes in Ready state
+```
+
+### Step 4 — Deploy Config Server first
+```bash
+kubectl apply -f k8s/config-server/deployment.yaml
+kubectl apply -f k8s/config-server/service.yaml
+
+# Wait for it to be ready
+kubectl rollout status deployment/config-server -n spring-petclinic
+```
+
+### Step 5 — Deploy Discovery Server
+```bash
+kubectl apply -f k8s/discovery-server/deployment.yaml
+kubectl apply -f k8s/discovery-server/service.yaml
+
+# Wait for it to be ready
+kubectl rollout status deployment/discovery-server -n spring-petclinic
+```
+
+### Step 6 — Verify Both Are Running
+```bash
+kubectl get pods -n spring-petclinic
+# Expected output:
+# NAME                                READY   STATUS    RESTARTS   AGE
+# config-server-xxxx                  1/1     Running   0          2m
+# discovery-server-xxxx               1/1     Running   0          1m
+```
+
+### Step 7 — Check Logs
+```bash
+# Config server logs
+kubectl logs -n spring-petclinic -l app=config-server --tail=20
+
+# Discovery server logs
+kubectl logs -n spring-petclinic -l app=discovery-server --tail=20
+```
+
+### Step 8 — Open Eureka Dashboard
+```bash
+kubectl port-forward -n spring-petclinic svc/discovery-server 8761:8761
+```
+Then open browser: `http://localhost:8761`
+
+You should see the Eureka dashboard with discovery-server registered.
+As other team members deploy their services, they will appear here too.
+
+---
+
+## Acceptance Criteria (from JIRA Issue #3)
+
+- [ ] All services register with Eureka
+- [ ] Config server serves correct configs per environment
+- [ ] Services can discover each other dynamically
+
+---
+
+## Useful Debug Commands
+```bash
+# Check pod status
+kubectl get pods -n spring-petclinic
+
+# Describe a pod if it's not starting
+kubectl describe pod -n spring-petclinic -l app=config-server
+kubectl describe pod -n spring-petclinic -l app=discovery-server
+
+# Check events for errors
+kubectl get events -n spring-petclinic --sort-by='.lastTimestamp'
+
+# Restart a deployment
+kubectl rollout restart deployment/config-server -n spring-petclinic
+kubectl rollout restart deployment/discovery-server -n spring-petclinic
+```
+
+---
+
+## Local Testing (Without EKS)
+Both services have been verified locally using Docker Compose:
+```bash
+docker compose up config-server discovery-server
+```
+- Config Server: http://localhost:8888/actuator/health → `{"status":"UP"}`
+- Discovery Server: http://localhost:8761 → Eureka dashboard loads
+- Config serving verified: http://localhost:8888/discovery-server/docker → configs returned

--- a/k8s/config-server/README.md
+++ b/k8s/config-server/README.md
@@ -1,231 +1,261 @@
 # Issue #3 — Config Server & Discovery Server (Eureka)
+
 **Branch:** `feature/issue-3-config-discovery`  
 **JIRA:** [Issue #3 - Configure service discovery and centralized config management](https://github.com/orgs/PetClinic-Project-Team/projects/1/views/2?pane=issue&itemId=184930136&issue=PetClinic-Project-Team%7Cspring-petclinic-microservices%7C3)  
 **Owner:** Harini (P4 — Config & Discovery Engineer)  
-**Status:** 🟡 In Progress — Pending AWS Account ID and ECR images from team
+**Status:** 🟢 Deployed and Verified on EKS  
+**Completed:** May 11, 2026
 
 ---
 
 ## What Is This Work?
 
 This folder contains the Kubernetes manifests to deploy two critical foundation
-services for the Spring PetClinic Microservices application on AWS EKS:
+services for the Spring PetClinic Microservices application on AWS EKS.
+
+These two services are the backbone of the entire application.
+Nothing else can start without them.
 
 ### 1. Config Server (port 8888)
-The Config Server is the **first service that must start** in the entire application.
-It acts as a central configuration manager — every other microservice (customers,
-vets, visits, api-gateway, genai, admin) fetches its settings from here on startup.
+The Config Server is the **first service that must start**.
+It acts as a central configuration manager — every other microservice
+fetches its settings from here on startup.
 
-It reads all configuration files from this external GitHub repository:
+It reads all configuration files from the external GitHub config repository:
 https://github.com/spring-petclinic/spring-petclinic-microservices-config
 
 Without Config Server running and healthy, NO other service can start.
 
 ### 2. Discovery Server / Eureka (port 8761)
 The Discovery Server is the **second service that must start**.
-It is a Eureka service registry — every microservice registers itself here
-when it starts up, and the API Gateway uses it to route traffic dynamically.
+It is a Eureka service registry — every microservice registers itself
+here when it starts up. The API Gateway uses Eureka to route traffic
+dynamically across multiple service instances.
 
-This is why the team decided to use Spring Boot native services instead of
-Kubernetes ConfigMap/DNS — the application is designed around this pattern.
-Replacing it would require significant code changes.
+### Startup Order (Critical)
 
-The startup dependency chain is:
-Config Server → Discovery Server → All other services
+Config Server  (port 8888)
+↓
+Discovery Server (port 8761)
+↓
+All other services (customers, vets, visits, api-gateway, genai, admin)
+
 
 ---
 
 ## Files in This Folder
 k8s/
 ├── config-server/
-│   ├── README.md          ← this file
-│   ├── deployment.yaml    ← K8s Deployment for config-server
-│   └── service.yaml       ← K8s ClusterIP Service on port 8888
+│   ├── README.md            ← this file
+│   ├── deployment.yaml      ← K8s Deployment for config-server
+│   └── service.yaml         ← K8s ClusterIP Service on port 8888
 └── discovery-server/
-├── deployment.yaml    ← K8s Deployment for discovery-server
-└── service.yaml       ← K8s ClusterIP Service on port 8761
+├── README.md            ← discovery server notes
+├── deployment.yaml      ← K8s Deployment for discovery-server
+└── service.yaml         ← K8s ClusterIP Service on port 8761
 
 ---
 
-## What Has Been Done ✅
+## Completed Work ✅
 
-- [x] Cloned team repo and created feature branch `feature/issue-3-config-discovery`
-- [x] Ran config-server and discovery-server locally using `docker compose up config-server discovery-server`
-- [x] Verified config-server health: `curl http://localhost:8888/actuator/health` → UP
-- [x] Verified config-server serves configs: `curl http://localhost:8888/discovery-server/docker` → configs returned from GitHub config repo
-- [x] Verified discovery-server health: `curl http://localhost:8761/actuator/health` → UP
-- [x] Verified Eureka dashboard at `http://localhost:8761` → loading correctly
-- [x] Created K8s folder structure: `k8s/config-server/` and `k8s/discovery-server/`
-- [x] Written `k8s/config-server/deployment.yaml` — Deployment with readiness + liveness probes
-- [x] Written `k8s/config-server/service.yaml` — ClusterIP Service on port 8888
-- [x] Written `k8s/discovery-server/deployment.yaml` — Deployment with initContainer that waits for config-server
-- [x] Written `k8s/discovery-server/service.yaml` — ClusterIP Service on port 8761
-
----
-
-## What Is Pending ⏳
-
-### Needed from P2 (Infrastructure Engineer):
-
-**1. AWS Account ID**
-The ECR image URLs in both deployment files currently use a placeholder:
-<ACCOUNT_ID>.dkr.ecr.us-east-1.amazonaws.com/petclinic/spring-petclinic-config-server:latest
-<ACCOUNT_ID>.dkr.ecr.us-east-1.amazonaws.com/petclinic/spring-petclinic-discovery-server:latest
-Once you share the AWS Account ID, replace it like this:
-```bash
-sed -i 's/<ACCOUNT_ID>/YOUR_ACTUAL_ACCOUNT_ID/g' k8s/config-server/deployment.yaml
-sed -i 's/<ACCOUNT_ID>/YOUR_ACTUAL_ACCOUNT_ID/g' k8s/discovery-server/deployment.yaml
-```
-
-**2. Confirm EKS cluster is running:**
-```bash
-aws eks update-kubeconfig --name petclinic-cluster --region us-east-1
-kubectl get nodes
-```
-
-**3. Confirm namespace exists:**
-```bash
-kubectl get namespace spring-petclinic
-# If not created yet:
-kubectl create namespace spring-petclinic
-```
-
-### Needed from P3 (CI/CD Engineer):
-
-**1. Confirm Docker images are built and pushed to ECR:**
-```bash
-aws ecr list-images --repository-name petclinic/spring-petclinic-config-server --region us-east-1
-aws ecr list-images --repository-name petclinic/spring-petclinic-discovery-server --region us-east-1
-```
-
-**2. Confirm image tag being used** (latest or specific version)
+- [x] Created feature branch `feature/issue-3-config-discovery`
+- [x] Ran both services locally using `docker compose up config-server discovery-server`
+- [x] Verified config-server health locally → `{"status":"UP"}`
+- [x] Verified config-server serves configs from GitHub config repo
+- [x] Verified Eureka dashboard loads at `http://localhost:8761`
+- [x] Written K8s Deployment + Service manifests for config-server
+- [x] Written K8s Deployment + Service manifests for discovery-server
+- [x] discovery-server uses initContainer to wait for config-server health
+- [x] Deployed config-server to EKS namespace `spring-petclinic` → `1/1 Running`
+- [x] Deployed discovery-server to EKS namespace `spring-petclinic` → `1/1 Running`
+- [x] Created ClusterIP services for both
+- [x] All smoke tests passed on EKS ✅
 
 ---
 
-## Why Is AWS Account ID Required?
+## Deployment Status on EKS
 
-AWS ECR (Elastic Container Registry) is a private Docker image registry.
-The full image URL format is:
-<account-id>.dkr.ecr.<region>.amazonaws.com/<repo-name>:<tag>
+| Resource | Name | Status | Port |
+|---|---|---|---|
+| Pod | config-server | 1/1 Running ✅ | 8888 |
+| Pod | discovery-server | 1/1 Running ✅ | 8761 |
+| Service | config-server | ClusterIP ✅ | 8888/TCP |
+| Service | discovery-server | ClusterIP ✅ | 8761/TCP |
 
-The Account ID is unique to your AWS account and is part of the ECR URL.
-Without it, Kubernetes cannot pull the Docker images and the pods will
-fail with `ImagePullBackOff` error.
-
-The ECR repositories are already created by P2 via Terraform:
-- `petclinic/spring-petclinic-config-server`
-- `petclinic/spring-petclinic-discovery-server`
-
-We just need the Account ID to complete the full URL.
+**Cluster:** petclinic-cluster  
+**Region:** us-east-1  
+**Namespace:** spring-petclinic  
 
 ---
 
-## How to Test Once Details Are Available
+## Smoke Test Results ✅
 
-### Prerequisites
-- kubectl installed and configured
-- AWS CLI configured with access to the shared AWS account
-- EKS cluster running (`petclinic-cluster` in `us-east-1`)
-- ECR images pushed by P3
-
-### Step 1 — Get the branch
+### Test 1 — Config Server Health (Local)
 ```bash
-git fetch origin
-git checkout feature/issue-3-config-discovery
+curl http://localhost:8888/actuator/health
 ```
+**Result:** ✅ PASSED
+- Config server UP and serving configs
+- Successfully reading from GitHub config repo
+- Version: 323993ce2519c6d02df63e08bf4458d123d3b611
+- Eureka settings confirmed
+- Prometheus metrics enabled
 
-### Step 2 — Replace Account ID
+### Test 2 — Config Server Health (EKS via port-forward)
 ```bash
-# Replace <ACCOUNT_ID> with the real AWS account ID from P2
-sed -i 's/<ACCOUNT_ID>/123456789012/g' k8s/config-server/deployment.yaml
-sed -i 's/<ACCOUNT_ID>/123456789012/g' k8s/discovery-server/deployment.yaml
+kubectl port-forward -n spring-petclinic svc/config-server 8888:8888
+curl http://localhost:8888/actuator/health
 ```
+**Result:** ✅ PASSED
+- Config server serving configs from GitHub config repo on EKS
+- All microservice configs available
+- Same config version as local test confirmed
 
-### Step 3 — Connect to EKS
+### Test 3 — Discovery Server Health (Local)
 ```bash
-aws eks update-kubeconfig --name petclinic-cluster --region us-east-1
-kubectl get nodes  # Should show nodes in Ready state
+curl http://localhost:8761/actuator/health
 ```
+**Result:** ✅ PASSED
+- `{"status":"UP"}`
+- Eureka server running correctly
 
-### Step 4 — Deploy Config Server first
-```bash
-kubectl apply -f k8s/config-server/deployment.yaml
-kubectl apply -f k8s/config-server/service.yaml
+### Test 4 — Eureka Dashboard (Local)
+Open browser: http://localhost:8761
+**Result:** ✅ PASSED
+- Eureka dashboard loads correctly
+- System Status: UP
+- Ready to accept service registrations
 
-# Wait for it to be ready
-kubectl rollout status deployment/config-server -n spring-petclinic
-```
-
-### Step 5 — Deploy Discovery Server
-```bash
-kubectl apply -f k8s/discovery-server/deployment.yaml
-kubectl apply -f k8s/discovery-server/service.yaml
-
-# Wait for it to be ready
-kubectl rollout status deployment/discovery-server -n spring-petclinic
-```
-
-### Step 6 — Verify Both Are Running
-```bash
-kubectl get pods -n spring-petclinic
-# Expected output:
-# NAME                                READY   STATUS    RESTARTS   AGE
-# config-server-xxxx                  1/1     Running   0          2m
-# discovery-server-xxxx               1/1     Running   0          1m
-```
-
-### Step 7 — Check Logs
-```bash
-# Config server logs
-kubectl logs -n spring-petclinic -l app=config-server --tail=20
-
-# Discovery server logs
-kubectl logs -n spring-petclinic -l app=discovery-server --tail=20
-```
-
-### Step 8 — Open Eureka Dashboard
+### Test 5 — Eureka Dashboard (EKS via port-forward)
 ```bash
 kubectl port-forward -n spring-petclinic svc/discovery-server 8761:8761
+# Open browser: http://localhost:8761
 ```
-Then open browser: `http://localhost:8761`
+**Result:** ✅ PASSED
+- Eureka dashboard loads on EKS
+- System Status: UP
+- Uptime confirmed
 
-You should see the Eureka dashboard with discovery-server registered.
-As other team members deploy their services, they will appear here too.
+### Test 6 — InitContainer Dependency Check
+**Result:** ✅ PASSED
+- discovery-server initContainer correctly waited for config-server
+- Logs confirmed: "Waiting for config-server..." → "Config server is ready!"
+- discovery-server only started AFTER config-server was healthy
+
+### Test 7 — Pod and Service Verification
+```bash
+kubectl get pods,svc -n spring-petclinic
+```
+**Result:** ✅ PASSED
+pod/config-server     1/1   Running   0   restarts
+pod/discovery-server  1/1   Running   0   restarts
+svc/config-server     ClusterIP   8888/TCP
+svc/discovery-server  ClusterIP   8761/TCP
 
 ---
 
-## Acceptance Criteria (from JIRA Issue #3)
+## Pending (Depends on Other Team Members) ⏳
 
+- [ ] Connect all microservices to config server
+      → P5 (customers + vets), P6 (visits + api-gateway) to deploy their services
+- [ ] Test service discovery between services
+      → Verify all services appear in Eureka dashboard after P5, P6 deploy
 - [ ] All services register with Eureka
-- [ ] Config server serves correct configs per environment
-- [ ] Services can discover each other dynamically
+      → Will be verified once full team deployment is complete
+
+---
+
+## What Other Services Need
+
+When other team members deploy their services,
+they must include these env vars in their K8s deployments:
+
+```yaml
+env:
+  - name: SPRING_PROFILES_ACTIVE
+    value: "docker"
+  - name: CONFIG_SERVER_URL
+    value: "http://config-server:8888"
+```
+
+The service names `config-server` and `discovery-server` are the
+Kubernetes service names — they resolve automatically inside the cluster.
+
+---
+
+## How to Connect and Verify (For Team Members)
+
+### Step 1 — Authenticate to AWS and Connect to EKS
+```bash
+# Configure AWS CLI with your credentials from P2
+aws configure
+
+# Assume EKS Developer Role (get role ARN from P2)
+aws sts assume-role \
+  --role-arn <ROLE_ARN_FROM_P2> \
+  --role-session-name dev-session
+
+# Export the temporary credentials from the output above
+export AWS_ACCESS_KEY_ID="..."
+export AWS_SECRET_ACCESS_KEY="..."
+export AWS_SESSION_TOKEN="..."
+
+# Connect to EKS cluster
+aws eks update-kubeconfig --name petclinic-cluster --region us-east-1
+```
+
+### Step 2 — Verify Pods and Services
+```bash
+kubectl get pods,svc -n spring-petclinic
+```
+
+### Step 3 — Test Config Server
+```bash
+kubectl port-forward -n spring-petclinic svc/config-server 8888:8888
+
+# In second terminal
+curl http://localhost:8888/actuator/health
+```
+
+### Step 4 — Open Eureka Dashboard
+```bash
+kubectl port-forward -n spring-petclinic svc/discovery-server 8761:8761
+# Open browser: http://localhost:8761
+```
 
 ---
 
 ## Useful Debug Commands
-```bash
-# Check pod status
-kubectl get pods -n spring-petclinic
 
-# Describe a pod if it's not starting
+```bash
+# Check all pods and services
+kubectl get pods,svc -n spring-petclinic
+
+# Check config-server logs
+kubectl logs -n spring-petclinic -l app=config-server --tail=20
+
+# Check discovery-server logs
+kubectl logs -n spring-petclinic -l app=discovery-server --tail=20
+
+# Describe pod if not starting
 kubectl describe pod -n spring-petclinic -l app=config-server
 kubectl describe pod -n spring-petclinic -l app=discovery-server
 
-# Check events for errors
+# Check cluster events for errors
 kubectl get events -n spring-petclinic --sort-by='.lastTimestamp'
 
-# Restart a deployment
+# Restart a deployment if needed
 kubectl rollout restart deployment/config-server -n spring-petclinic
 kubectl rollout restart deployment/discovery-server -n spring-petclinic
 ```
 
 ---
 
-## Local Testing (Without EKS)
-Both services have been verified locally using Docker Compose:
-```bash
-docker compose up config-server discovery-server
-```
-- Config Server: http://localhost:8888/actuator/health → `{"status":"UP"}`
-- Discovery Server: http://localhost:8761 → Eureka dashboard loads
-- Config serving verified: http://localhost:8888/discovery-server/docker → configs returned
+## JIRA Acceptance Criteria
+
+| Criteria | Status |
+|---|---|
+| Config server serves correct configs per environment | ✅ Verified on EKS |
+| Discovery server (Eureka) running | ✅ Verified on EKS |
+| All services register with Eureka | ⏳ Waiting for other services |
+| Services can discover each other dynamically | ⏳ Waiting for other services |

--- a/k8s/config-server/deployment.yaml
+++ b/k8s/config-server/deployment.yaml
@@ -17,7 +17,7 @@ spec:
     spec:
       containers:
         - name: config-server
-          image: <ACCOUNT_ID>.dkr.ecr.us-east-1.amazonaws.com/petclinic/spring-petclinic-config-server:latest
+          image: 989800606347.dkr.ecr.us-east-1.amazonaws.com/petclinic/spring-petclinic-config-server:latest
           ports:
             - containerPort: 8888
           env:

--- a/k8s/config-server/deployment.yaml
+++ b/k8s/config-server/deployment.yaml
@@ -1,0 +1,46 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: config-server
+  namespace: spring-petclinic
+  labels:
+    app: config-server
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: config-server
+  template:
+    metadata:
+      labels:
+        app: config-server
+    spec:
+      containers:
+        - name: config-server
+          image: <ACCOUNT_ID>.dkr.ecr.us-east-1.amazonaws.com/petclinic/spring-petclinic-config-server:latest
+          ports:
+            - containerPort: 8888
+          env:
+            - name: SPRING_PROFILES_ACTIVE
+              value: "docker"
+          resources:
+            requests:
+              memory: "256Mi"
+              cpu: "250m"
+            limits:
+              memory: "512Mi"
+              cpu: "500m"
+          readinessProbe:
+            httpGet:
+              path: /actuator/health
+              port: 8888
+            initialDelaySeconds: 30
+            periodSeconds: 10
+            failureThreshold: 5
+          livenessProbe:
+            httpGet:
+              path: /actuator/health
+              port: 8888
+            initialDelaySeconds: 60
+            periodSeconds: 15
+            failureThreshold: 3

--- a/k8s/config-server/service.yaml
+++ b/k8s/config-server/service.yaml
@@ -1,0 +1,15 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: config-server
+  namespace: spring-petclinic
+  labels:
+    app: config-server
+spec:
+  selector:
+    app: config-server
+  ports:
+    - protocol: TCP
+      port: 8888
+      targetPort: 8888
+  type: ClusterIP

--- a/k8s/discovery-server/README.md
+++ b/k8s/discovery-server/README.md
@@ -1,0 +1,12 @@
+# Discovery Server (Eureka)
+See the main README in `k8s/config-server/README.md` for full documentation.
+
+This folder contains:
+- `deployment.yaml` — K8s Deployment for discovery-server (port 8761)
+- `service.yaml` — K8s ClusterIP Service on port 8761
+
+Key points:
+- Uses an initContainer to wait for config-server to be healthy before starting
+- Spring profile: docker
+- CONFIG_SERVER_URL points to http://config-server:8888 (K8s service name)
+- Must start BEFORE customers, vets, visits, api-gateway, genai, admin services

--- a/k8s/discovery-server/README.md
+++ b/k8s/discovery-server/README.md
@@ -1,12 +1,22 @@
 # Discovery Server (Eureka)
-See the main README in `k8s/config-server/README.md` for full documentation.
 
-This folder contains:
-- `deployment.yaml` — K8s Deployment for discovery-server (port 8761)
-- `service.yaml` — K8s ClusterIP Service on port 8761
+See the main README in `k8s/config-server/README.md` for full documentation,
+smoke test results, and team instructions.
 
-Key points:
-- Uses an initContainer to wait for config-server to be healthy before starting
-- Spring profile: docker
-- CONFIG_SERVER_URL points to http://config-server:8888 (K8s service name)
-- Must start BEFORE customers, vets, visits, api-gateway, genai, admin services
+## Quick Summary
+
+| Item | Detail |
+|---|---|
+| Port | 8761 |
+| Type | Eureka Service Registry |
+| Status | 1/1 Running on EKS ✅ |
+| Service | ClusterIP 8761/TCP ✅ |
+| Depends on | config-server (via initContainer) |
+| Spring Profile | docker |
+| Config URL | http://config-server:8888 |
+
+## Access Eureka Dashboard
+```bash
+kubectl port-forward -n spring-petclinic svc/discovery-server 8761:8761
+# Open: http://localhost:8761
+```

--- a/k8s/discovery-server/deployment.yaml
+++ b/k8s/discovery-server/deployment.yaml
@@ -29,7 +29,7 @@ spec:
               echo "Config server is ready!"
       containers:
         - name: discovery-server
-          image: <ACCOUNT_ID>.dkr.ecr.us-east-1.amazonaws.com/petclinic/spring-petclinic-discovery-server:latest
+          image: 989800606347.dkr.ecr.us-east-1.amazonaws.com/petclinic/spring-petclinic-discovery-server:latest
           ports:
             - containerPort: 8761
           env:

--- a/k8s/discovery-server/deployment.yaml
+++ b/k8s/discovery-server/deployment.yaml
@@ -1,0 +1,60 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: discovery-server
+  namespace: spring-petclinic
+  labels:
+    app: discovery-server
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: discovery-server
+  template:
+    metadata:
+      labels:
+        app: discovery-server
+    spec:
+      initContainers:
+        - name: wait-for-config-server
+          image: curlimages/curl:latest
+          command:
+            - sh
+            - -c
+            - |
+              until curl -sf http://config-server:8888/actuator/health; do
+                echo "Waiting for config-server..."
+                sleep 5
+              done
+              echo "Config server is ready!"
+      containers:
+        - name: discovery-server
+          image: <ACCOUNT_ID>.dkr.ecr.us-east-1.amazonaws.com/petclinic/spring-petclinic-discovery-server:latest
+          ports:
+            - containerPort: 8761
+          env:
+            - name: SPRING_PROFILES_ACTIVE
+              value: "docker"
+            - name: CONFIG_SERVER_URL
+              value: "http://config-server:8888"
+          resources:
+            requests:
+              memory: "256Mi"
+              cpu: "250m"
+            limits:
+              memory: "512Mi"
+              cpu: "500m"
+          readinessProbe:
+            httpGet:
+              path: /actuator/health
+              port: 8761
+            initialDelaySeconds: 30
+            periodSeconds: 10
+            failureThreshold: 5
+          livenessProbe:
+            httpGet:
+              path: /actuator/health
+              port: 8761
+            initialDelaySeconds: 60
+            periodSeconds: 15
+            failureThreshold: 3

--- a/k8s/discovery-server/service.yaml
+++ b/k8s/discovery-server/service.yaml
@@ -1,0 +1,15 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: discovery-server
+  namespace: spring-petclinic
+  labels:
+    app: discovery-server
+spec:
+  selector:
+    app: discovery-server
+  ports:
+    - protocol: TCP
+      port: 8761
+      targetPort: 8761
+  type: ClusterIP


### PR DESCRIPTION
## Issue #3 - Configure service discovery and centralized config management

### What this PR adds:
- K8s Deployment + ClusterIP Service for config-server (port 8888)
- K8s Deployment + ClusterIP Service for discovery-server (port 8761)
- discovery-server uses initContainer to wait for config-server
- Full README with smoke test results and team instructions

### Smoke Tests Passed ✅
- Config server health verified locally and on EKS
- Config server serving configs from GitHub config repo
- Eureka dashboard verified locally and on EKS
- Both pods running 1/1 with 0 restarts
- InitContainer dependency working correctly

### Pending (other team members)
- Other services registering with Eureka (P5, P6)
- Full service discovery test once all services deployed