### PR TITLE
Auto-close invalid PRs and enforce PR template completion

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,0 +1,24 @@
+## Description
+
+<!-- Please describe your change clearly. If it fixes a bug, link the issue. -->
+
+Fixes # (issue)
+
+## Type of change
+
+- [ ] Bug fix
+- [ ] New feature
+- [ ] Documentation update
+- [ ] Dependency upgrade
+
+## Checklist
+
+- [ ] I have read the [CONTRIBUTING](../CONTRIBUTING.md) guide
+- [ ] **This is NOT coursework, a student assignment, or homework** — I understand that forks of this repo are widely used in courses and that student PRs will be closed without review
+- [ ] My change targets the `main` branch of **spring-petclinic/spring-petclinic-microservices**, not my own fork
+- [ ] I have tested this change locally
+- [ ] Existing tests pass (`./mvnw test`)
+
+> ⚠️ **Are you a student?**  
+> If you forked this repo for a course or bootcamp, your changes belong in **your own fork**, not here.  
+> PRs that are part of a course assignment will be labelled `invalid` and closed immediately.

--- a/.github/workflows/check-pr-template.yml
+++ b/.github/workflows/check-pr-template.yml
@@ -1,0 +1,176 @@
+name: Check PR template completeness
+
+on:
+  pull_request_target:
+    types: [opened, reopened, edited]
+  schedule:
+    - cron: '0 8 * * *'   # every day at 08:00 UTC
+
+permissions:
+  pull-requests: write
+  issues: write
+
+jobs:
+  # ── 1. On every PR open/edit: check that the template was filled in ──────────
+  check-template:
+    if: ${{ github.event_name == 'pull_request_target' }}
+    runs-on: ubuntu-latest
+    steps:
+      - name: Ensure needs-information label exists
+        uses: actions/github-script@v7
+        with:
+          script: |
+            try {
+              await github.rest.issues.createLabel({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                name: 'needs-information',
+                color: 'e4e669',
+                description: 'More information is needed before this can be reviewed',
+              });
+            } catch (e) {
+              if (e.status !== 422) throw e; // 422 = already exists, ignore
+            }
+
+      - name: Detect incomplete template
+        uses: actions/github-script@v7
+        with:
+          script: |
+            const { data: pr } = await github.rest.pulls.get({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              pull_number: context.payload.pull_request.number,
+            });
+
+            const body = pr.body || '';
+
+            function isIncomplete(body) {
+              if (body.trim().length < 30) return true;
+              // Template HTML comment still present → body was never edited
+              if (body.includes('<!-- Please describe your change')) return true;
+              // The placeholder issue reference was not replaced
+              if (/Fixes\s*#\s*\(issue\)/.test(body)) return true;
+              // All checklist items still unchecked
+              const unchecked = (body.match(/- \[ \]/g) || []).length;
+              const checked   = (body.match(/- \[x\]/gi) || []).length;
+              if (unchecked >= 3 && checked === 0) return true;
+              return false;
+            }
+
+            const labels = pr.labels.map(l => l.name);
+            const alreadyFlagged = labels.includes('needs-information');
+
+            if (isIncomplete(body)) {
+              if (!alreadyFlagged) {
+                await github.rest.issues.addLabels({
+                  owner: context.repo.owner,
+                  repo: context.repo.repo,
+                  issue_number: pr.number,
+                  labels: ['needs-information'],
+                });
+
+                await github.rest.issues.createComment({
+                  owner: context.repo.owner,
+                  repo: context.repo.repo,
+                  issue_number: pr.number,
+                  body: [
+                    `## 📋 Please complete the PR template, @${pr.user.login}`,
+                    '',
+                    'It looks like the Pull Request description is **empty or hasn\'t been filled in** yet.',
+                    '',
+                    'To help maintainers review your contribution, please:',
+                    '',
+                    '1. Edit this PR and fill in the description template:',
+                    '   - Describe **what** your change does and **why**',
+                    '   - Link the related issue (e.g. `Fixes #123`)',
+                    '   - Tick the checklist items that apply',
+                    '',
+                    '2. Once the template is complete, the `needs-information` label will be removed automatically.',
+                    '',
+                    '> **Note:** If this PR is not updated within **7 days**, it will be closed automatically. You are welcome to re-open it once the description is complete.',
+                    '',
+                    '_This is an automated message._',
+                  ].join('\n'),
+                });
+                console.log(`PR #${pr.number} flagged as needs-information.`);
+              } else {
+                console.log(`PR #${pr.number} still incomplete, already flagged.`);
+              }
+            } else {
+              // Template is now complete — remove the label if it was set
+              if (alreadyFlagged) {
+                await github.rest.issues.removeLabel({
+                  owner: context.repo.owner,
+                  repo: context.repo.repo,
+                  issue_number: pr.number,
+                  name: 'needs-information',
+                });
+                await github.rest.issues.createComment({
+                  owner: context.repo.owner,
+                  repo: context.repo.repo,
+                  issue_number: pr.number,
+                  body: `Thanks for completing the PR template, @${pr.user.login}! The \`needs-information\` label has been removed. A maintainer will review your PR shortly. 🙏`,
+                });
+                console.log(`PR #${pr.number} template now complete, label removed.`);
+              } else {
+                console.log(`PR #${pr.number} template looks complete.`);
+              }
+            }
+
+  # ── 2. Daily: close PRs still labelled needs-information after 7 days ─────────
+  close-stale-incomplete:
+    if: ${{ github.event_name == 'schedule' }}
+    runs-on: ubuntu-latest
+    steps:
+      - name: Close PRs with incomplete template after 7 days of inactivity
+        uses: actions/github-script@v7
+        with:
+          script: |
+            const sevenDaysAgo = new Date(Date.now() - 7 * 24 * 60 * 60 * 1000);
+
+            // Fetch all open PRs labelled needs-information (paginate if needed)
+            const prs = await github.paginate(github.rest.pulls.list, {
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              state: 'open',
+              per_page: 100,
+            });
+
+            for (const pr of prs) {
+              const hasLabel = pr.labels.some(l => l.name === 'needs-information');
+              if (!hasLabel) continue;
+
+              const lastUpdate = new Date(pr.updated_at);
+              if (lastUpdate >= sevenDaysAgo) {
+                console.log(`PR #${pr.number} flagged but still recent (${pr.updated_at}), skipping.`);
+                continue;
+              }
+
+              console.log(`Closing PR #${pr.number} — no activity for 7+ days with incomplete template.`);
+
+              await github.rest.issues.createComment({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                issue_number: pr.number,
+                body: [
+                  '## PR closed — template not completed',
+                  '',
+                  `Hi @${pr.user.login},`,
+                  '',
+                  'This Pull Request has been **automatically closed** because the description template was not completed within 7 days.',
+                  '',
+                  'You are welcome to **re-open it** once the template is fully filled in. A complete description helps maintainers understand the context and intent of your change.',
+                  '',
+                  `See our [CONTRIBUTING guide](https://github.com/${context.repo.owner}/${context.repo.repo}/blob/${context.payload.repository.default_branch}/CONTRIBUTING.md) for details.`,
+                  '',
+                  '_This is an automated message._',
+                ].join('\n'),
+              });
+
+              await github.rest.pulls.update({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                pull_number: pr.number,
+                state: 'closed',
+              });
+            }

--- a/.github/workflows/close-student-prs.yml
+++ b/.github/workflows/close-student-prs.yml
@@ -1,0 +1,84 @@
+name: Close invalid PRs from student assignments
+
+on:
+  pull_request_target:
+    types: [opened, reopened, edited]
+
+permissions:
+  issues: write
+  pull-requests: write
+
+jobs:
+  detect-student-pr:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Check for student/course assignment patterns
+        uses: actions/github-script@v7
+        with:
+          script: |
+            const { data: pr } = await github.rest.pulls.get({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              pull_number: context.payload.pull_request.number,
+            });
+
+            const title = pr.title || '';
+            const body = pr.body || '';
+            const branch = pr.head.ref || '';
+            const combined = `${title} ${body} ${branch}`.toLowerCase();
+
+            // Patterns commonly seen in student course submissions
+            const studentPatterns = [
+              /\bspc-\d+/i,                    // SPC-001, SPC-003-T1 …
+              /add\s+(jenkins|gitlab|github\s+actions)\s+(ci|pipeline)/i,
+              /add\s+ci\s+(workflow|pipeline)/i,
+              /push\s+(image|docker)\s+to\s+(ecr|dockerhub|registry)/i,
+              /add\s+(kubernetes|k8s)\s+manifests?/i,
+              /add\s+monitoring\s+(stack|dashboard)/i,
+              /\bdevops\s+(project|assignment|lab|homework|tp)\b/i,
+              /\b(lab|tp|homework|assignment|exercise)\s*[#\d]/i,
+              /\bbootcamp\b/i,
+            ];
+
+            const matched = studentPatterns.find((pattern) => pattern.test(combined));
+
+            if (matched) {
+              console.log(`Pattern matched: ${matched}`);
+
+              await github.rest.issues.addLabels({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                issue_number: pr.number,
+                labels: ['invalid'],
+              });
+
+              await github.rest.issues.createComment({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                issue_number: pr.number,
+                body: [
+                  `## 👋 Hi @${pr.user.login},`,
+                  '',
+                  'It looks like this Pull Request may be part of a **course assignment or bootcamp exercise**.',
+                  '',
+                  'This repository is widely used as a training project, but PRs that are part of coursework are **out of scope** for the upstream project and will be closed.',
+                  '',
+                  'Your changes belong in **your own fork** — that is where your instructor will review them.',
+                  '',
+                  `Please read our [CONTRIBUTING guide](https://github.com/${context.repo.owner}/${context.repo.repo}/blob/${context.payload.repository.default_branch}/CONTRIBUTING.md) for details on what kinds of contributions we accept.`,
+                  '',
+                  '_This is an automated message. If you believe this was a mistake, please re-open and leave a comment explaining why your PR is not course-related._',
+                ].join('\n'),
+              });
+
+              await github.rest.pulls.update({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                pull_number: pr.number,
+                state: 'closed',
+              });
+
+              console.log(`PR #${pr.number} closed as student assignment.`);
+            } else {
+              console.log('No student patterns detected — PR looks legitimate.');
+            }

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,42 @@
+# Contributing to Spring PetClinic Microservices
+
+Thank you for your interest in contributing!
+
+## ⚠️ Are you a student or course participant?
+
+This repository is widely used as a **training exercise** in DevOps, cloud, and Java courses.  
+If you forked this repo as part of a course, bootcamp, or homework assignment:
+
+- **Your changes belong in your own fork**, not here.
+- Pull Requests that are part of a course assignment (CI pipelines, Kubernetes manifests, monitoring additions, etc.) will be labelled `invalid` and **closed without review**.
+- This is not personal. It is simply not the scope of this project.
+
+## What we accept
+
+- Bug fixes with a linked issue
+- Dependency upgrades (Spring Boot, Spring Cloud ...)
+- Documentation improvements
+- Features discussed and agreed upon in an issue first
+
+## What we do NOT accept
+
+- Course assignments or homework submissions
+- PRs adding Jenkins/GitLab CI, ECR pipelines, or cloud-specific infrastructure for educational purposes
+- PRs that duplicate already-open contributions
+- Changes without tests
+
+## How to contribute
+
+1. **Open an issue first** to discuss the change you want to make.
+2. Fork the repository and create a branch: `git checkout -b bugfix/my-bug-fix`
+3. Make your changes and add tests if applicable.
+4. Run the test suite: `./mvnw test`
+5. Open a Pull Request using the provided template and fill it out completely.
+
+## Reporting a bug
+
+Open an issue with:
+- A clear description of the bug
+- Steps to reproduce
+- Expected vs actual behaviour
+- Spring Boot / Java version


### PR DESCRIPTION
Add workflows to filter student PRs and enforce PR template completion

- Automatically closes PRs detected as student assignments (invalid label, comment, immediate close)
- Automatically checks PR template completion (needs-information label, comment, closes after 7 days without update)
- YAML syntax fixes and needs-information label harmonization
- Follows Spring conventions for labeling and messaging

These workflows aim to reduce student PR spam and improve contribution quality.