### PR TITLE
Added Kubernetes manifests and Docker setup for visits-service and api-gatewayFeature/visits api gateway k8s

### DIFF
--- a/spring-petclinic-api-gateway/Dockerfile
+++ b/spring-petclinic-api-gateway/Dockerfile
@@ -1,0 +1,9 @@
+FROM eclipse-temurin:17-jre-alpine
+
+WORKDIR /app
+
+COPY target/*.jar app.jar
+
+EXPOSE 8080
+
+ENTRYPOINT ["java", "-jar", "app.jar"]

--- a/spring-petclinic-api-gateway/k8s/api-gateway-deployment.yaml
+++ b/spring-petclinic-api-gateway/k8s/api-gateway-deployment.yaml
@@ -1,0 +1,46 @@
+apiVersion: apps/v1
+kind: Deployment
+
+metadata:
+  name: api-gateway
+  labels:
+    app: api-gateway
+
+spec:
+  replicas: 1
+
+  selector:
+    matchLabels:
+      app: api-gateway
+
+  template:
+    metadata:
+      labels:
+        app: api-gateway
+
+    spec:
+      containers:
+        - name: api-gateway
+          image: api-gateway:latest
+          imagePullPolicy: Never
+
+          ports:
+            - containerPort: 8080
+
+          env:
+            - name: SPRING_CLOUD_CONFIG_ENABLED
+              value: "false"
+
+          readinessProbe:
+            httpGet:
+              path: /actuator/health/readiness
+              port: 8080
+            initialDelaySeconds: 20
+            periodSeconds: 10
+
+          livenessProbe:
+            httpGet:
+              path: /actuator/health/liveness
+              port: 8080
+            initialDelaySeconds: 30
+            periodSeconds: 15

--- a/spring-petclinic-api-gateway/k8s/api-gateway-service.yaml
+++ b/spring-petclinic-api-gateway/k8s/api-gateway-service.yaml
@@ -1,0 +1,17 @@
+apiVersion: v1
+kind: Service
+
+metadata:
+  name: api-gateway
+
+spec:
+  selector:
+    app: api-gateway
+
+  ports:
+    - protocol: TCP
+      port: 8080
+      targetPort: 8080
+      nodePort: 30080
+
+  type: NodePort

--- a/spring-petclinic-api-gateway/src/main/resources/application.yml
+++ b/spring-petclinic-api-gateway/src/main/resources/application.yml
@@ -1,8 +1,11 @@
 spring:
   application:
     name: api-gateway
+
+  # TEMP: disable config server for Docker/local testing stability
   config:
-    import: optional:configserver:${CONFIG_SERVER_URL:http://localhost:8888/}
+    import: optional:configserver:${CONFIG_SERVER_URL:http://config-server:8888}
+
   cloud:
     gateway:
       server:
@@ -16,38 +19,40 @@ spring:
               args:
                 retries: 1
                 statuses: SERVICE_UNAVAILABLE
-                methods: POST
+                methods: GET,POST
+
           routes:
             - id: vets-service
-              uri: lb://vets-service
+              uri: http://vets-service:8080
               predicates:
                 - Path=/api/vet/**
               filters:
                 - StripPrefix=2
+
             - id: visits-service
-              uri: lb://visits-service
+              uri: http://visits-service:8080
               predicates:
                 - Path=/api/visit/**
               filters:
                 - StripPrefix=2
+
             - id: customers-service
-              uri: lb://customers-service
+              uri: http://customers-service:8080
               predicates:
                 - Path=/api/customer/**
               filters:
                 - StripPrefix=2
+
             - id: genai-service
-              uri: lb://genai-service
+              uri: http://genai-service:8080
               predicates:
                 - Path=/api/genai/**
               filters:
                 - StripPrefix=2
-                - CircuitBreaker=name=genaiCircuitBreaker,fallbackUri=/fallback
+                - name: CircuitBreaker
+                  args:
+                    name: genaiCircuitBreaker
+                    fallbackUri: forward:/fallback
+
   reactor:
     context-propagation: auto
----
-spring:
-  config:
-    activate:
-      on-profile: docker
-    import: configserver:http://config-server:8888

--- a/spring-petclinic-visits-service/Dockerfile
+++ b/spring-petclinic-visits-service/Dockerfile
@@ -1,0 +1,9 @@
+FROM eclipse-temurin:17-jre-alpine
+
+WORKDIR /app
+
+COPY target/*.jar app.jar
+
+EXPOSE 8080
+
+ENTRYPOINT ["java","-jar","app.jar"]

--- a/spring-petclinic-visits-service/k8s/visits-deployment.yaml
+++ b/spring-petclinic-visits-service/k8s/visits-deployment.yaml
@@ -1,0 +1,49 @@
+apiVersion: apps/v1
+kind: Deployment
+
+metadata:
+  name: visits-service
+  labels:
+    app: visits-service
+
+spec:
+  replicas: 1
+
+  selector:
+    matchLabels:
+      app: visits-service
+
+  template:
+    metadata:
+      labels:
+        app: visits-service
+
+    spec:
+      containers:
+        - name: visits-service
+          image: visits-service:latest
+          imagePullPolicy: Never
+
+          ports:
+            - containerPort: 8080
+
+          env:
+            - name: SERVER_PORT
+              value: "8080"
+
+            - name: SPRING_CLOUD_CONFIG_ENABLED
+              value: "false"
+
+          readinessProbe:
+            httpGet:
+              path: /actuator/health/readiness
+              port: 8080
+            initialDelaySeconds: 20
+            periodSeconds: 10
+
+          livenessProbe:
+            httpGet:
+              path: /actuator/health/liveness
+              port: 8080
+            initialDelaySeconds: 30
+            periodSeconds: 15

--- a/spring-petclinic-visits-service/k8s/visits-service.yaml
+++ b/spring-petclinic-visits-service/k8s/visits-service.yaml
@@ -1,0 +1,16 @@
+apiVersion: v1
+kind: Service
+
+metadata:
+  name: visits-service
+
+spec:
+  selector:
+    app: visits-service
+
+  ports:
+    - protocol: TCP
+      port: 8080
+      targetPort: 8080
+
+  type: ClusterIP


### PR DESCRIPTION
## Summary

Implemented Kubernetes deployment setup for:

* visits-service
* api-gateway

## Changes Made

* Added Dockerfiles
* Added Kubernetes Deployment manifests
* Added Kubernetes Service manifests
* Configured NodePort exposure for API Gateway
* Verified pod communication in kind cluster
* Tested actuator health endpoints

## Notes

* Spring Cloud Config was temporarily disabled for local kind testing
* Services are prepared for future EKS deployment
