### PR TITLE
Add missing pet not found web test

### DIFF
--- a/spring-petclinic-customers-service/src/test/java/org/springframework/samples/petclinic/customers/web/PetResourceTest.java
+++ b/spring-petclinic-customers-service/src/test/java/org/springframework/samples/petclinic/customers/web/PetResourceTest.java
@@ -53,6 +53,14 @@ class PetResourceTest {
             .andExpect(jsonPath("$.name").value("Basil"))
             .andExpect(jsonPath("$.type.id").value(6));
     }
+    
+    @Test
+    void shouldReturnNotFoundWhenPetDoesNotExist() throws Exception {
+        given(petRepository.findById(99)).willReturn(Optional.empty());
+
+        mvc.perform(get("/owners/2/pets/99").accept(MediaType.APPLICATION_JSON))
+            .andExpect(status().isNotFound());
+    }
 
     private Pet setupPet() {
         Owner owner = new Owner();


### PR DESCRIPTION
## Description

Adds web-layer test coverage for the missing-pet case in `PetResourceTest`.

`PetResource` already throws `ResourceNotFoundException` when a pet id cannot be found, which is mapped to HTTP 404. This PR verifies that `GET /owners/{ownerId}/pets/{petId}` returns `404 Not Found` when the requested pet does not exist.

Fixes # (issue)

N/A — test coverage improvement.

## Type of change

- [ ] Bug fix
- [ ] New feature
- [ ] Documentation update
- [ ] Dependency upgrade
- [x] Test coverage improvement

## Checklist

- [x] I have read the [CONTRIBUTING](../CONTRIBUTING.md) guide
- [x] **This is NOT coursework, a student assignment, or homework** — I understand that forks of this repo are widely used in courses and that student PRs will be closed without review
- [x] My change targets the `main` branch of **spring-petclinic/spring-petclinic-microservices**, not my own fork
- [x] I have tested this change locally
- [x] Existing tests pass (`./mvnw test`)
