### PR TITLE
Create ci workflow

### DIFF
--- a/.github/workflows/maven-build.yml
+++ b/.github/workflows/maven-build.yml
@@ -10,20 +10,43 @@ on:
     branches: [ main ]
 
 jobs:
-  build:
-
+  build-and-test:
     runs-on: ubuntu-latest
-    strategy:
-      matrix:
-        java: [ '17' ]
 
     steps:
-    - uses: actions/checkout@v4
-    - name: Set up JDK ${{matrix.java}}
-      uses: actions/setup-java@v4
-      with:
-        java-version: ${{matrix.java}}
-        distribution: 'adopt'
-        cache: maven
-    - name: Build with Maven
-      run: mvn -B package --file pom.xml
+      - name: Checkout source
+        uses: actions/checkout@v4
+
+      - name: Set up JDK 17
+        uses: actions/setup-java@v4
+        with:
+          java-version: '17'
+          distribution: 'temurin'
+          cache: maven
+
+      - name: Build all modules (compile only)
+        run: ./mvnw -B package -DskipTests --file pom.xml
+
+      - name: Test customers-service
+        run: ./mvnw -B test -pl spring-petclinic-customers-service
+
+      - name: Test vets-service
+        run: ./mvnw -B test -pl spring-petclinic-vets-service
+
+      - name: Test visits-service
+        run: ./mvnw -B test -pl spring-petclinic-visits-service
+
+      - name: Test admin-server
+        run: ./mvnw -B test -pl spring-petclinic-admin-server
+
+      - name: Upload JaCoCo coverage reports
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: jacoco-reports
+          path: |
+            spring-petclinic-customers-service/target/site/jacoco/
+            spring-petclinic-vets-service/target/site/jacoco/
+            spring-petclinic-visits-service/target/site/jacoco/
+            spring-petclinic-admin-server/target/site/jacoco/
+          retention-days: 14

--- a/spring-petclinic-admin-server/pom.xml
+++ b/spring-petclinic-admin-server/pom.xml
@@ -52,6 +52,13 @@
             <version>${spring-boot-admin.version}</version>
         </dependency>
 
+        <!-- Testing -->
+        <dependency>
+            <groupId>org.springframework.boot</groupId>
+            <artifactId>spring-boot-starter-test</artifactId>
+            <scope>test</scope>
+        </dependency>
+
         <!-- Third-party librairies -->
         <dependency>
             <groupId>org.jolokia</groupId>

--- a/spring-petclinic-admin-server/src/test/java/org/springframework/samples/petclinic/admin/SpringBootAdminApplicationTest.java
+++ b/spring-petclinic-admin-server/src/test/java/org/springframework/samples/petclinic/admin/SpringBootAdminApplicationTest.java
@@ -1,0 +1,14 @@
+package org.springframework.samples.petclinic.admin;
+
+import org.junit.jupiter.api.Test;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.test.context.ActiveProfiles;
+
+@SpringBootTest
+@ActiveProfiles("test")
+class SpringBootAdminApplicationTest {
+
+    @Test
+    void contextLoads() {
+    }
+}

--- a/spring-petclinic-admin-server/src/test/resources/application-test.yml
+++ b/spring-petclinic-admin-server/src/test/resources/application-test.yml
@@ -1,0 +1,10 @@
+spring:
+  cloud:
+    config:
+      enabled: false
+
+eureka:
+  client:
+    enabled: false
+
+logging.level.org.springframework: INFO

--- a/spring-petclinic-customers-service/src/test/java/org/springframework/samples/petclinic/customers/web/PetResourceTest.java
+++ b/spring-petclinic-customers-service/src/test/java/org/springframework/samples/petclinic/customers/web/PetResourceTest.java
@@ -5,12 +5,14 @@ import java.util.Optional;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.webmvc.test.autoconfigure.WebMvcTest;
+import org.springframework.context.annotation.Import;
 import org.springframework.http.MediaType;
 import org.springframework.samples.petclinic.customers.model.Owner;
 import org.springframework.samples.petclinic.customers.model.OwnerRepository;
 import org.springframework.samples.petclinic.customers.model.Pet;
 import org.springframework.samples.petclinic.customers.model.PetRepository;
 import org.springframework.samples.petclinic.customers.model.PetType;
+import org.springframework.samples.petclinic.customers.web.mapper.OwnerEntityMapper;
 import org.springframework.test.context.ActiveProfiles;
 import org.springframework.test.context.bean.override.mockito.MockitoBean;
 import org.springframework.test.web.servlet.MockMvc;
@@ -18,6 +20,7 @@ import org.springframework.test.web.servlet.MockMvc;
 
 import static org.mockito.BDDMockito.given;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.content;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
@@ -25,7 +28,8 @@ import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.
 /**
  * @author Maciej Szarlinski
  */
-@WebMvcTest(PetResource.class)
+@WebMvcTest({PetResource.class, OwnerResource.class})
+@Import(OwnerEntityMapper.class)
 @ActiveProfiles("test")
 class PetResourceTest {
 
@@ -52,6 +56,44 @@ class PetResourceTest {
             .andExpect(jsonPath("$.id").value(2))
             .andExpect(jsonPath("$.name").value("Basil"))
             .andExpect(jsonPath("$.type.id").value(6));
+    }
+
+    @Test
+    void shouldRejectCreatePetForMissingOwner() throws Exception {
+        given(ownerRepository.findById(99)).willReturn(Optional.empty());
+
+        mvc.perform(post("/owners/99/pets")
+                .contentType("application/json")
+                .content("""
+                    {
+                        "id": 0,
+                        "name": "Fluffy",
+                        "typeId": 1
+                    }
+                """))
+            .andExpect(status().isNotFound());
+    }
+
+    @Test
+    void shouldRejectBlankInput() throws Exception {
+        mvc.perform(post("/owners")
+                .contentType("application/json")
+                .content("""
+                    {
+                      "firstName": "",
+                      "lastName": "TestLastName",
+                      "address": "YorkU",
+                      "city": "Markham",
+                      "telephone": "1234567890"
+                    }
+                    """))
+            .andExpect(status().isBadRequest());
+    }
+
+    @Test
+    void shouldRejectInvalidOwnerId() throws Exception {
+        mvc.perform(get("/owners/0"))
+            .andExpect(status().isBadRequest());
     }
 
     private Pet setupPet() {

--- a/spring-petclinic-visits-service/src/test/java/org/springframework/samples/petclinic/visits/web/VisitResourceTest.java
+++ b/spring-petclinic-visits-service/src/test/java/org/springframework/samples/petclinic/visits/web/VisitResourceTest.java
@@ -12,7 +12,9 @@ import org.springframework.test.web.servlet.MockMvc;
 
 import static java.util.Arrays.asList;
 import static org.mockito.BDDMockito.given;
+
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 
@@ -54,5 +56,11 @@ class VisitResourceTest {
             .andExpect(jsonPath("$.items[0].petId").value(111))
             .andExpect(jsonPath("$.items[1].petId").value(222))
             .andExpect(jsonPath("$.items[2].petId").value(222));
+    }
+
+    @Test
+    void shouldRejectInvalidVisitBody() throws Exception {
+        mvc.perform(post("/owners/1/pets/1/visits"))
+            .andExpect(status().isBadRequest());
     }
 }


### PR DESCRIPTION
## Running CI Results

```
[INFO] Scanning for projects...
[INFO] ------------------------------------------------------------------------
[INFO] Reactor Build Order:
[INFO] 
[INFO] spring-petclinic-admin-server                                      [jar]
[INFO] spring-petclinic-customers-service                                 [jar]
[INFO] spring-petclinic-vets-service                                      [jar]
[INFO] spring-petclinic-visits-service                                    [jar]
[INFO] 
[INFO] --< org.springframework.samples.petclinic.admin:spring-petclinic-admin-server >--
[INFO] Building spring-petclinic-admin-server 4.0.1                       [1/4]
[INFO]   from pom.xml
[INFO] --------------------------------[ jar ]---------------------------------
[INFO] 
[INFO] --- enforcer:3.6.2:enforce (enforce-java) @ spring-petclinic-admin-server ---
[INFO] Rule 0: org.apache.maven.enforcer.rules.version.RequireJavaVersion passed
[INFO] 
[INFO] --- git-commit-id:9.0.2:revision (default) @ spring-petclinic-admin-server ---
[INFO] dotGitDirectory '/Users/girachawda/3241/spring-petclinic-microservices/.git'
[INFO] Collected git.build.user.name with value Gira Chawda
[INFO] Collected git.build.user.email with value girachawda101@gmail.com
[INFO] Collected git.branch with value create-ci-workflow
[INFO] Collected git.commit.id.describe with value dede0df
[INFO] Collected git.commit.id.describe-short with value dede0df
[INFO] Collected git.commit.id with value dede0dfe84c00a1dc5ba5721f14611092293555f
[INFO] Collected git.commit.id.abbrev with value dede0df
[INFO] Collected git.dirty with value false
[INFO] Collected git.commit.user.name with value Gira Chawda
[INFO] Collected git.commit.user.email with value girachawda101@gmail.com
[INFO] Collected git.commit.message.full with value Create CI github workflow
[INFO] Collected git.commit.message.short with value Create CI github workflow
[INFO] Collected git.commit.time with value 2026-07-05T19:28:01-0400
[INFO] Collected git.commit.author.time with value 2026-07-05T19:28:01-0400
[INFO] Collected git.commit.committer.time with value 2026-07-05T19:28:01-0400
[INFO] Collected git.remote.origin.url with value https://github.com/spring-petclinic/spring-petclinic-microservices.git
[INFO] Collected git.tags with value 
[INFO] Collected git.tag with value 
[INFO] Collected git.closest.tag.name with value 
[INFO] Collected git.closest.tag.commit.count with value 
[INFO] Collected git.total.commit.count with value 760
[INFO] Collected git.local.branch.ahead with value 0
[INFO] Collected git.local.branch.behind with value 0
[INFO] Collected git.build.time with value 2026-07-05T19:41:57-0400
[INFO] Collected git.build.version with value 4.0.1
[INFO] Collected git.build.host with value Giras-MacBook-Air.local
[INFO] including property 'git.tags' in results
[INFO] including property 'git.build.version' in results
[INFO] including property 'git.branch' in results
[INFO] including property 'git.build.host' in results
[INFO] including property 'git.commit.id' in results
[INFO] including property 'git.commit.user.email' in results
[INFO] including property 'git.local.branch.behind' in results
[INFO] including property 'git.commit.author.time' in results
[INFO] including property 'git.build.user.name' in results
[INFO] including property 'git.dirty' in results
[INFO] including property 'git.closest.tag.commit.count' in results
[INFO] including property 'git.commit.user.name' in results
[INFO] including property 'git.commit.id.abbrev' in results
[INFO] including property 'git.commit.id.describe-short' in results
[INFO] including property 'git.total.commit.count' in results
[INFO] including property 'git.commit.id.describe' in results
[INFO] including property 'git.build.user.email' in results
[INFO] including property 'git.commit.message.short' in results
[INFO] including property 'git.commit.committer.time' in results
[INFO] including property 'git.tag' in results
[INFO] including property 'git.closest.tag.name' in results
[INFO] including property 'git.local.branch.ahead' in results
[INFO] including property 'git.commit.time' in results
[INFO] including property 'git.build.time' in results
[INFO] including property 'git.commit.message.full' in results
[INFO] including property 'git.remote.origin.url' in results
[INFO] Reading existing properties file [/Users/girachawda/3241/spring-petclinic-microservices/spring-petclinic-admin-server/target/classes/git.properties] (for project spring-petclinic-admin-server)...
[INFO] Writing properties file [/Users/girachawda/3241/spring-petclinic-microservices/spring-petclinic-admin-server/target/classes/git.properties] (for project spring-petclinic-admin-server)...
[INFO] 
[INFO] --- jacoco:0.8.12:prepare-agent (jacoco-prepare-agent) @ spring-petclinic-admin-server ---
[INFO] argLine set to -javaagent:/Users/girachawda/.m2/repository/org/jacoco/org.jacoco.agent/0.8.12/org.jacoco.agent-0.8.12-runtime.jar=destfile=/Users/girachawda/3241/spring-petclinic-microservices/spring-petclinic-admin-server/target/jacoco.exec
[INFO] 
[INFO] --- spring-boot:4.0.1:build-info (default) @ spring-petclinic-admin-server ---
[INFO] 
[INFO] --- resources:3.3.1:resources (default-resources) @ spring-petclinic-admin-server ---
[INFO] Copying 1 resource from src/main/resources to target/classes
[INFO] Copying 1 resource from src/main/resources to target/classes
[INFO] 
[INFO] --- compiler:3.14.1:compile (default-compile) @ spring-petclinic-admin-server ---
[INFO] Nothing to compile - all classes are up to date.
[INFO] 
[INFO] --- resources:3.3.1:testResources (default-testResources) @ spring-petclinic-admin-server ---
[INFO] Copying 1 resource from src/test/resources to target/test-classes
[INFO] 
[INFO] --- compiler:3.14.1:testCompile (default-testCompile) @ spring-petclinic-admin-server ---
[INFO] Nothing to compile - all classes are up to date.
[INFO] 
[INFO] --- surefire:3.5.4:test (default-test) @ spring-petclinic-admin-server ---
[INFO] Using auto detected provider org.apache.maven.surefire.junitplatform.JUnitPlatformProvider
[INFO] 
[INFO] -------------------------------------------------------
[INFO]  T E S T S
[INFO] -------------------------------------------------------
[INFO] Running org.springframework.samples.petclinic.admin.SpringBootAdminApplicationTest
19:41:58.340 [main] INFO org.springframework.test.context.support.AnnotationConfigContextLoaderUtils -- Could not detect default configuration classes for test class [org.springframework.samples.petclinic.admin.SpringBootAdminApplicationTest]: SpringBootAdminApplicationTest does not declare any static, non-private, non-final, nested classes annotated with @Configuration.
19:41:58.403 [main] INFO org.springframework.boot.test.context.SpringBootTestContextBootstrapper -- Found @SpringBootConfiguration org.springframework.samples.petclinic.admin.SpringBootAdminApplication for test class org.springframework.samples.petclinic.admin.SpringBootAdminApplicationTest
19:41:59,108 |-WARN in ch.qos.logback.core.model.processor.ImplicitModelHandler - Ignoring unknown property [jmxConfigurator] in [ch.qos.logback.classic.LoggerContext]

  .   ____          _            __ _ _
 /\\ / ___'_ __ _ _(_)_ __  __ _ \ \ \ \
( ( )\___ | '_ | '_| | '_ \/ _` | \ \ \ \
 \\/  ___)| |_)| | | | | || (_| |  ) ) ) )
  '  |____| .__|_| |_|_| |_\__, | / / / /
 =========|_|==============|___/=/_/_/_/

 :: Spring Boot ::                (v4.0.1)

2026-07-05T19:41:59.201-04:00  INFO 39175 --- [admin-server] [           main] o.s.s.p.a.SpringBootAdminApplicationTest : Starting SpringBootAdminApplicationTest using Java 23 with PID 39175 (started by girachawda in /Users/girachawda/3241/spring-petclinic-microservices/spring-petclinic-admin-server)
2026-07-05T19:41:59.202-04:00  INFO 39175 --- [admin-server] [           main] o.s.s.p.a.SpringBootAdminApplicationTest : The following 1 profile is active: "test"
2026-07-05T19:41:59.223-04:00  INFO 39175 --- [admin-server] [           main] o.s.c.c.c.ConfigServerConfigDataLoader   : Fetching config from server at : http://localhost:8888/
2026-07-05T19:41:59.224-04:00  INFO 39175 --- [admin-server] [           main] o.s.c.c.c.ConfigServerConfigDataLoader   : Exception on Url - http://localhost:8888/:org.springframework.web.client.ResourceAccessException: I/O error on GET request for "http://localhost:8888/admin-server/default": Connection refused. Will be trying the next url if available
2026-07-05T19:41:59.224-04:00  WARN 39175 --- [admin-server] [           main] o.s.c.c.c.ConfigServerConfigDataLoader   : Could not locate PropertySource ([ConfigServerConfigDataResource@340c7479 uris = array<String>['http://localhost:8888/'], optional = true, profiles = 'default']): I/O error on GET request for "http://localhost:8888/admin-server/default": Connection refused
2026-07-05T19:41:59.224-04:00  INFO 39175 --- [admin-server] [           main] o.s.c.c.c.ConfigServerConfigDataLoader   : Fetching config from server at : http://localhost:8888/
2026-07-05T19:41:59.224-04:00  INFO 39175 --- [admin-server] [           main] o.s.c.c.c.ConfigServerConfigDataLoader   : Exception on Url - http://localhost:8888/:org.springframework.web.client.ResourceAccessException: I/O error on GET request for "http://localhost:8888/admin-server/test": Connection refused. Will be trying the next url if available
2026-07-05T19:41:59.224-04:00  WARN 39175 --- [admin-server] [           main] o.s.c.c.c.ConfigServerConfigDataLoader   : Could not locate PropertySource ([ConfigServerConfigDataResource@66859ea9 uris = array<String>['http://localhost:8888/'], optional = true, profiles = 'test']): I/O error on GET request for "http://localhost:8888/admin-server/test": Connection refused
2026-07-05T19:41:59.224-04:00  INFO 39175 --- [admin-server] [           main] o.s.c.c.c.ConfigServerConfigDataLoader   : Fetching config from server at : http://localhost:8888/
2026-07-05T19:41:59.225-04:00  INFO 39175 --- [admin-server] [           main] o.s.c.c.c.ConfigServerConfigDataLoader   : Exception on Url - http://localhost:8888/:org.springframework.web.client.ResourceAccessException: I/O error on GET request for "http://localhost:8888/admin-server/default": Connection refused. Will be trying the next url if available
2026-07-05T19:41:59.225-04:00  WARN 39175 --- [admin-server] [           main] o.s.c.c.c.ConfigServerConfigDataLoader   : Could not locate PropertySource ([ConfigServerConfigDataResource@4a9412c4 uris = array<String>['http://localhost:8888/'], optional = true, profiles = 'default']): I/O error on GET request for "http://localhost:8888/admin-server/default": Connection refused
2026-07-05T19:41:59.715-04:00  INFO 39175 --- [admin-server] [           main] o.s.cloud.context.scope.GenericScope     : BeanFactory id=572e5e90-89ed-3c57-9d1a-c7152d15c0b6
2026-07-05T19:41:59.930-04:00  WARN 39175 --- [admin-server] [           main] ion$DefaultTemplateResolverConfiguration : Cannot find template location: classpath:/templates/ (please add some templates, check your Thymeleaf configuration, or set spring.thymeleaf.check-template-location=false)
2026-07-05T19:42:00.061-04:00  INFO 39175 --- [admin-server] [           main] o.s.b.a.e.web.EndpointLinksResolver      : Exposing 1 endpoint beneath base path '/actuator'
2026-07-05T19:42:00.303-04:00 ERROR 39175 --- [admin-server] [           main] i.n.r.d.DnsServerAddressStreamProviders  : Unable to load io.netty.resolver.dns.macos.MacOSDnsServerAddressStreamProvider, fallback to system defaults. This may result in incorrect DNS resolutions on MacOS. Check whether you have a dependency on 'io.netty:netty-resolver-dns-native-macos'. Use DEBUG level to see the full stack: java.lang.UnsatisfiedLinkError: failed to load the required native library
2026-07-05T19:42:00.357-04:00  INFO 39175 --- [admin-server] [           main] DiscoveryClientOptionalArgsConfiguration : Eureka HTTP Client uses RestClient.
2026-07-05T19:42:00.471-04:00  INFO 39175 --- [admin-server] [           main] o.s.s.p.a.SpringBootAdminApplicationTest : Started SpringBootAdminApplicationTest in 1.867 seconds (process running for 2.804)
Mockito is currently self-attaching to enable the inline-mock-maker. This will no longer work in future releases of the JDK. Please add Mockito as an agent to your build as described in Mockito's documentation: https://javadoc.io/doc/org.mockito/mockito-core/latest/org.mockito/org/mockito/Mockito.html#0.3
Java HotSpot(TM) 64-Bit Server VM warning: Sharing is only supported for boot loader classes because bootstrap classpath has been appended
WARNING: A Java agent has been loaded dynamically (/Users/girachawda/.m2/repository/net/bytebuddy/byte-buddy-agent/1.17.8/byte-buddy-agent-1.17.8.jar)
WARNING: If a serviceability tool is in use, please run with -XX:+EnableDynamicAgentLoading to hide this warning
WARNING: If a serviceability tool is not in use, please run with -Djdk.instrument.traceUsage for more information
WARNING: Dynamic loading of agents will be disallowed by default in a future release
[INFO] Tests run: 1, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 2.702 s -- in org.springframework.samples.petclinic.admin.SpringBootAdminApplicationTest
[INFO] 
[INFO] Results:
[INFO] 
[INFO] Tests run: 1, Failures: 0, Errors: 0, Skipped: 0
[INFO] 
[INFO] 
[INFO] --- jacoco:0.8.12:report (jacoco-report) @ spring-petclinic-admin-server ---
[INFO] Loading execution data file /Users/girachawda/3241/spring-petclinic-microservices/spring-petclinic-admin-server/target/jacoco.exec
[INFO] Analyzed bundle 'spring-petclinic-admin-server' with 1 classes
[INFO] 
[INFO] --< org.springframework.samples.petclinic.client:spring-petclinic-customers-service >--
[INFO] Building spring-petclinic-customers-service 4.0.1                  [2/4]
[INFO]   from /Users/girachawda/3241/spring-petclinic-microservices/spring-petclinic-customers-service/pom.xml
[INFO] --------------------------------[ jar ]---------------------------------
[INFO] 
[INFO] --- enforcer:3.6.2:enforce (enforce-java) @ spring-petclinic-customers-service ---
[INFO] 
[INFO] --- git-commit-id:9.0.2:revision (default) @ spring-petclinic-customers-service ---
[INFO] dotGitDirectory '/Users/girachawda/3241/spring-petclinic-microservices/.git'
[INFO] Collected git.build.user.name with value Gira Chawda
[INFO] Collected git.build.user.email with value girachawda101@gmail.com
[INFO] Collected git.branch with value create-ci-workflow
[INFO] Collected git.commit.id.describe with value dede0df
[INFO] Collected git.commit.id.describe-short with value dede0df
[INFO] Collected git.commit.id with value dede0dfe84c00a1dc5ba5721f14611092293555f
[INFO] Collected git.commit.id.abbrev with value dede0df
[INFO] Collected git.dirty with value false
[INFO] Collected git.commit.user.name with value Gira Chawda
[INFO] Collected git.commit.user.email with value girachawda101@gmail.com
[INFO] Collected git.commit.message.full with value Create CI github workflow
[INFO] Collected git.commit.message.short with value Create CI github workflow
[INFO] Collected git.commit.time with value 2026-07-05T19:28:01-0400
[INFO] Collected git.commit.author.time with value 2026-07-05T19:28:01-0400
[INFO] Collected git.commit.committer.time with value 2026-07-05T19:28:01-0400
[INFO] Collected git.remote.origin.url with value https://github.com/spring-petclinic/spring-petclinic-microservices.git
[INFO] Collected git.tags with value 
[INFO] Collected git.tag with value 
[INFO] Collected git.closest.tag.name with value 
[INFO] Collected git.closest.tag.commit.count with value 
[INFO] Collected git.total.commit.count with value 760
[INFO] Collected git.local.branch.ahead with value 0
[INFO] Collected git.local.branch.behind with value 0
[INFO] Collected git.build.time with value 2026-07-05T19:42:03-0400
[INFO] Collected git.build.version with value 4.0.1
[INFO] Collected git.build.host with value Giras-MacBook-Air.local
[INFO] including property 'git.tags' in results
[INFO] including property 'git.build.version' in results
[INFO] including property 'git.branch' in results
[INFO] including property 'git.build.host' in results
[INFO] including property 'git.commit.id' in results
[INFO] including property 'git.commit.user.email' in results
[INFO] including property 'git.local.branch.behind' in results
[INFO] including property 'git.commit.author.time' in results
[INFO] including property 'git.build.user.name' in results
[INFO] including property 'git.dirty' in results
[INFO] including property 'git.closest.tag.commit.count' in results
[INFO] including property 'git.commit.user.name' in results
[INFO] including property 'git.commit.id.abbrev' in results
[INFO] including property 'git.commit.id.describe-short' in results
[INFO] including property 'git.total.commit.count' in results
[INFO] including property 'git.commit.id.describe' in results
[INFO] including property 'git.build.user.email' in results
[INFO] including property 'git.commit.message.short' in results
[INFO] including property 'git.commit.committer.time' in results
[INFO] including property 'git.tag' in results
[INFO] including property 'git.closest.tag.name' in results
[INFO] including property 'git.local.branch.ahead' in results
[INFO] including property 'git.commit.time' in results
[INFO] including property 'git.build.time' in results
[INFO] including property 'git.commit.message.full' in results
[INFO] including property 'git.remote.origin.url' in results
[INFO] Reading existing properties file [/Users/girachawda/3241/spring-petclinic-microservices/spring-petclinic-customers-service/target/classes/git.properties] (for project spring-petclinic-customers-service)...
[INFO] Writing properties file [/Users/girachawda/3241/spring-petclinic-microservices/spring-petclinic-customers-service/target/classes/git.properties] (for project spring-petclinic-customers-service)...
[INFO] 
[INFO] --- jacoco:0.8.12:prepare-agent (jacoco-prepare-agent) @ spring-petclinic-customers-service ---
[INFO] argLine set to -javaagent:/Users/girachawda/.m2/repository/org/jacoco/org.jacoco.agent/0.8.12/org.jacoco.agent-0.8.12-runtime.jar=destfile=/Users/girachawda/3241/spring-petclinic-microservices/spring-petclinic-customers-service/target/jacoco.exec
[INFO] 
[INFO] --- spring-boot:4.0.1:build-info (default) @ spring-petclinic-customers-service ---
[INFO] 
[INFO] --- resources:3.3.1:resources (default-resources) @ spring-petclinic-customers-service ---
[INFO] Copying 1 resource from src/main/resources to target/classes
[INFO] Copying 5 resources from src/main/resources to target/classes
[INFO] 
[INFO] --- compiler:3.14.1:compile (default-compile) @ spring-petclinic-customers-service ---
[INFO] Nothing to compile - all classes are up to date.
[INFO] 
[INFO] --- resources:3.3.1:testResources (default-testResources) @ spring-petclinic-customers-service ---
[INFO] Copying 1 resource from src/test/resources to target/test-classes
[INFO] 
[INFO] --- compiler:3.14.1:testCompile (default-testCompile) @ spring-petclinic-customers-service ---
[INFO] Nothing to compile - all classes are up to date.
[INFO] 
[INFO] --- surefire:3.5.4:test (default-test) @ spring-petclinic-customers-service ---
[INFO] Using auto detected provider org.apache.maven.surefire.junitplatform.JUnitPlatformProvider
[INFO] 
[INFO] -------------------------------------------------------
[INFO]  T E S T S
[INFO] -------------------------------------------------------
[INFO] Running org.springframework.samples.petclinic.customers.web.PetResourceTest
19:42:04.286 [main] INFO org.springframework.test.context.support.AnnotationConfigContextLoaderUtils -- Could not detect default configuration classes for test class [org.springframework.samples.petclinic.customers.web.PetResourceTest]: PetResourceTest does not declare any static, non-private, non-final, nested classes annotated with @Configuration.
19:42:04.395 [main] INFO org.springframework.boot.test.context.SpringBootTestContextBootstrapper -- Found @SpringBootConfiguration org.springframework.samples.petclinic.customers.CustomersServiceApplication for test class org.springframework.samples.petclinic.customers.web.PetResourceTest
19:42:05,126 |-WARN in ch.qos.logback.core.model.processor.ImplicitModelHandler - Ignoring unknown property [jmxConfigurator] in [ch.qos.logback.classic.LoggerContext]

  .   ____          _            __ _ _
 /\\ / ___'_ __ _ _(_)_ __  __ _ \ \ \ \
( ( )\___ | '_ | '_| | '_ \/ _` | \ \ \ \
 \\/  ___)| |_)| | | | | || (_| |  ) ) ) )
  '  |____| .__|_| |_|_| |_\__, | / / / /
 =========|_|==============|___/=/_/_/_/

 :: Spring Boot ::                (v4.0.1)

2026-07-05T19:42:05.228-04:00  INFO 39188 --- [customers-service] [           main] [                                                 ] o.s.s.p.customers.web.PetResourceTest    : Starting PetResourceTest using Java 23 with PID 39188 (started by girachawda in /Users/girachawda/3241/spring-petclinic-microservices/spring-petclinic-customers-service)
2026-07-05T19:42:05.229-04:00  INFO 39188 --- [customers-service] [           main] [                                                 ] o.s.s.p.customers.web.PetResourceTest    : The following 1 profile is active: "test"
2026-07-05T19:42:05.237-04:00  INFO 39188 --- [customers-service] [           main] [                                                 ] o.s.c.c.c.ConfigServerConfigDataLoader   : Fetching config from server at : http://localhost:8888/
2026-07-05T19:42:05.238-04:00  INFO 39188 --- [customers-service] [           main] [                                                 ] o.s.c.c.c.ConfigServerConfigDataLoader   : Exception on Url - http://localhost:8888/:org.springframework.web.client.ResourceAccessException: I/O error on GET request for "http://localhost:8888/customers-service/default": Connection refused. Will be trying the next url if available
2026-07-05T19:42:05.238-04:00  WARN 39188 --- [customers-service] [           main] [                                                 ] o.s.c.c.c.ConfigServerConfigDataLoader   : Could not locate PropertySource ([ConfigServerConfigDataResource@325e03b uris = array<String>['http://localhost:8888/'], optional = true, profiles = 'default']): I/O error on GET request for "http://localhost:8888/customers-service/default": Connection refused
2026-07-05T19:42:05.238-04:00  INFO 39188 --- [customers-service] [           main] [                                                 ] o.s.c.c.c.ConfigServerConfigDataLoader   : Fetching config from server at : http://localhost:8888/
2026-07-05T19:42:05.238-04:00  INFO 39188 --- [customers-service] [           main] [                                                 ] o.s.c.c.c.ConfigServerConfigDataLoader   : Exception on Url - http://localhost:8888/:org.springframework.web.client.ResourceAccessException: I/O error on GET request for "http://localhost:8888/customers-service/test": Connection refused. Will be trying the next url if available
2026-07-05T19:42:05.238-04:00  WARN 39188 --- [customers-service] [           main] [                                                 ] o.s.c.c.c.ConfigServerConfigDataLoader   : Could not locate PropertySource ([ConfigServerConfigDataResource@110318a7 uris = array<String>['http://localhost:8888/'], optional = true, profiles = 'test']): I/O error on GET request for "http://localhost:8888/customers-service/test": Connection refused
2026-07-05T19:42:05.239-04:00  INFO 39188 --- [customers-service] [           main] [                                                 ] o.s.c.c.c.ConfigServerConfigDataLoader   : Fetching config from server at : http://localhost:8888/
2026-07-05T19:42:05.239-04:00  INFO 39188 --- [customers-service] [           main] [                                                 ] o.s.c.c.c.ConfigServerConfigDataLoader   : Exception on Url - http://localhost:8888/:org.springframework.web.client.ResourceAccessException: I/O error on GET request for "http://localhost:8888/customers-service/default": Connection refused. Will be trying the next url if available
2026-07-05T19:42:05.239-04:00  WARN 39188 --- [customers-service] [           main] [                                                 ] o.s.c.c.c.ConfigServerConfigDataLoader   : Could not locate PropertySource ([ConfigServerConfigDataResource@42ac309 uris = array<String>['http://localhost:8888/'], optional = true, profiles = 'default']): I/O error on GET request for "http://localhost:8888/customers-service/default": Connection refused
Mockito is currently self-attaching to enable the inline-mock-maker. This will no longer work in future releases of the JDK. Please add Mockito as an agent to your build as described in Mockito's documentation: https://javadoc.io/doc/org.mockito/mockito-core/latest/org.mockito/org/mockito/Mockito.html#0.3
Java HotSpot(TM) 64-Bit Server VM warning: Sharing is only supported for boot loader classes because bootstrap classpath has been appended
WARNING: A Java agent has been loaded dynamically (/Users/girachawda/.m2/repository/net/bytebuddy/byte-buddy-agent/1.17.8/byte-buddy-agent-1.17.8.jar)
WARNING: If a serviceability tool is in use, please run with -XX:+EnableDynamicAgentLoading to hide this warning
WARNING: If a serviceability tool is not in use, please run with -Djdk.instrument.traceUsage for more information
WARNING: Dynamic loading of agents will be disallowed by default in a future release
2026-07-05T19:42:06.556-04:00  INFO 39188 --- [customers-service] [           main] [                                                 ] o.s.b.t.m.w.SpringBootMockServletContext : Initializing Spring TestDispatcherServlet ''
2026-07-05T19:42:06.556-04:00  INFO 39188 --- [customers-service] [           main] [                                                 ] o.s.t.web.servlet.TestDispatcherServlet  : Initializing Servlet ''
2026-07-05T19:42:06.557-04:00  INFO 39188 --- [customers-service] [           main] [                                                 ] o.s.t.web.servlet.TestDispatcherServlet  : Completed initialization in 1 ms
2026-07-05T19:42:06.574-04:00  INFO 39188 --- [customers-service] [           main] [                                                 ] o.s.s.p.customers.web.PetResourceTest    : Started PetResourceTest in 2.0 seconds (process running for 3.011)
2026-07-05T19:42:06.712-04:00  WARN 39188 --- [customers-service] [           main] [                                                 ] .w.s.m.s.DefaultHandlerExceptionResolver : Resolved [org.springframework.web.bind.MethodArgumentNotValidException: Validation failed for argument [0] in public org.springframework.samples.petclinic.customers.model.Owner org.springframework.samples.petclinic.customers.web.OwnerResource.createOwner(org.springframework.samples.petclinic.customers.web.OwnerRequest): [Field error in object 'ownerRequest' on field 'firstName': rejected value []; codes [NotBlank.ownerRequest.firstName,NotBlank.firstName,NotBlank.java.lang.String,NotBlank]; arguments [org.springframework.context.support.DefaultMessageSourceResolvable: codes [ownerRequest.firstName,firstName]; arguments []; default message [firstName]]; default message [must not be blank]] ]
[INFO] Tests run: 4, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 2.633 s -- in org.springframework.samples.petclinic.customers.web.PetResourceTest
[INFO] 
[INFO] Results:
[INFO] 
[INFO] Tests run: 4, Failures: 0, Errors: 0, Skipped: 0
[INFO] 
[INFO] 
[INFO] --- jacoco:0.8.12:report (jacoco-report) @ spring-petclinic-customers-service ---
[INFO] Loading execution data file /Users/girachawda/3241/spring-petclinic-microservices/spring-petclinic-customers-service/target/jacoco.exec
[INFO] Analyzed bundle 'spring-petclinic-customers-service' with 12 classes
[INFO] 
[INFO] --< org.springframework.samples.petclinic.vets:spring-petclinic-vets-service >--
[INFO] Building spring-petclinic-vets-service 4.0.1                       [3/4]
[INFO]   from /Users/girachawda/3241/spring-petclinic-microservices/spring-petclinic-vets-service/pom.xml
[INFO] --------------------------------[ jar ]---------------------------------
[INFO] 
[INFO] --- enforcer:3.6.2:enforce (enforce-java) @ spring-petclinic-vets-service ---
[INFO] 
[INFO] --- git-commit-id:9.0.2:revision (default) @ spring-petclinic-vets-service ---
[INFO] dotGitDirectory '/Users/girachawda/3241/spring-petclinic-microservices/.git'
[INFO] Collected git.build.user.name with value Gira Chawda
[INFO] Collected git.build.user.email with value girachawda101@gmail.com
[INFO] Collected git.branch with value create-ci-workflow
[INFO] Collected git.commit.id.describe with value dede0df
[INFO] Collected git.commit.id.describe-short with value dede0df
[INFO] Collected git.commit.id with value dede0dfe84c00a1dc5ba5721f14611092293555f
[INFO] Collected git.commit.id.abbrev with value dede0df
[INFO] Collected git.dirty with value false
[INFO] Collected git.commit.user.name with value Gira Chawda
[INFO] Collected git.commit.user.email with value girachawda101@gmail.com
[INFO] Collected git.commit.message.full with value Create CI github workflow
[INFO] Collected git.commit.message.short with value Create CI github workflow
[INFO] Collected git.commit.time with value 2026-07-05T19:28:01-0400
[INFO] Collected git.commit.author.time with value 2026-07-05T19:28:01-0400
[INFO] Collected git.commit.committer.time with value 2026-07-05T19:28:01-0400
[INFO] Collected git.remote.origin.url with value https://github.com/spring-petclinic/spring-petclinic-microservices.git
[INFO] Collected git.tags with value 
[INFO] Collected git.tag with value 
[INFO] Collected git.closest.tag.name with value 
[INFO] Collected git.closest.tag.commit.count with value 
[INFO] Collected git.total.commit.count with value 760
[INFO] Collected git.local.branch.ahead with value 0
[INFO] Collected git.local.branch.behind with value 0
[INFO] Collected git.build.time with value 2026-07-05T19:42:07-0400
[INFO] Collected git.build.version with value 4.0.1
[INFO] Collected git.build.host with value Giras-MacBook-Air.local
[INFO] including property 'git.tags' in results
[INFO] including property 'git.build.version' in results
[INFO] including property 'git.branch' in results
[INFO] including property 'git.build.host' in results
[INFO] including property 'git.commit.id' in results
[INFO] including property 'git.commit.user.email' in results
[INFO] including property 'git.local.branch.behind' in results
[INFO] including property 'git.commit.author.time' in results
[INFO] including property 'git.build.user.name' in results
[INFO] including property 'git.dirty' in results
[INFO] including property 'git.closest.tag.commit.count' in results
[INFO] including property 'git.commit.user.name' in results
[INFO] including property 'git.commit.id.abbrev' in results
[INFO] including property 'git.commit.id.describe-short' in results
[INFO] including property 'git.total.commit.count' in results
[INFO] including property 'git.commit.id.describe' in results
[INFO] including property 'git.build.user.email' in results
[INFO] including property 'git.commit.message.short' in results
[INFO] including property 'git.commit.committer.time' in results
[INFO] including property 'git.tag' in results
[INFO] including property 'git.closest.tag.name' in results
[INFO] including property 'git.local.branch.ahead' in results
[INFO] including property 'git.commit.time' in results
[INFO] including property 'git.build.time' in results
[INFO] including property 'git.commit.message.full' in results
[INFO] including property 'git.remote.origin.url' in results
[INFO] Reading existing properties file [/Users/girachawda/3241/spring-petclinic-microservices/spring-petclinic-vets-service/target/classes/git.properties] (for project spring-petclinic-vets-service)...
[INFO] Writing properties file [/Users/girachawda/3241/spring-petclinic-microservices/spring-petclinic-vets-service/target/classes/git.properties] (for project spring-petclinic-vets-service)...
[INFO] 
[INFO] --- jacoco:0.8.12:prepare-agent (jacoco-prepare-agent) @ spring-petclinic-vets-service ---
[INFO] argLine set to -javaagent:/Users/girachawda/.m2/repository/org/jacoco/org.jacoco.agent/0.8.12/org.jacoco.agent-0.8.12-runtime.jar=destfile=/Users/girachawda/3241/spring-petclinic-microservices/spring-petclinic-vets-service/target/jacoco.exec
[INFO] 
[INFO] --- spring-boot:4.0.1:build-info (default) @ spring-petclinic-vets-service ---
[INFO] 
[INFO] --- resources:3.3.1:resources (default-resources) @ spring-petclinic-vets-service ---
[INFO] Copying 1 resource from src/main/resources to target/classes
[INFO] Copying 5 resources from src/main/resources to target/classes
[INFO] 
[INFO] --- compiler:3.14.1:compile (default-compile) @ spring-petclinic-vets-service ---
[INFO] Nothing to compile - all classes are up to date.
[INFO] 
[INFO] --- resources:3.3.1:testResources (default-testResources) @ spring-petclinic-vets-service ---
[INFO] Copying 1 resource from src/test/resources to target/test-classes
[INFO] 
[INFO] --- compiler:3.14.1:testCompile (default-testCompile) @ spring-petclinic-vets-service ---
[INFO] Nothing to compile - all classes are up to date.
[INFO] 
[INFO] --- surefire:3.5.4:test (default-test) @ spring-petclinic-vets-service ---
[INFO] Using auto detected provider org.apache.maven.surefire.junitplatform.JUnitPlatformProvider
[INFO] 
[INFO] -------------------------------------------------------
[INFO]  T E S T S
[INFO] -------------------------------------------------------
[INFO] Running org.springframework.samples.petclinic.vets.web.VetResourceTest
19:42:07.837 [main] INFO org.springframework.test.context.support.AnnotationConfigContextLoaderUtils -- Could not detect default configuration classes for test class [org.springframework.samples.petclinic.vets.web.VetResourceTest]: VetResourceTest does not declare any static, non-private, non-final, nested classes annotated with @Configuration.
19:42:07.925 [main] INFO org.springframework.boot.test.context.SpringBootTestContextBootstrapper -- Found @SpringBootConfiguration org.springframework.samples.petclinic.vets.VetsServiceApplication for test class org.springframework.samples.petclinic.vets.web.VetResourceTest
19:42:08,645 |-WARN in ch.qos.logback.core.model.processor.ImplicitModelHandler - Ignoring unknown property [jmxConfigurator] in [ch.qos.logback.classic.LoggerContext]

  .   ____          _            __ _ _
 /\\ / ___'_ __ _ _(_)_ __  __ _ \ \ \ \
( ( )\___ | '_ | '_| | '_ \/ _` | \ \ \ \
 \\/  ___)| |_)| | | | | || (_| |  ) ) ) )
  '  |____| .__|_| |_|_| |_\__, | / / / /
 =========|_|==============|___/=/_/_/_/

 :: Spring Boot ::                (v4.0.1)

2026-07-05T19:42:08.741-04:00  INFO 39200 --- [vets-service] [           main] [                                                 ] o.s.s.p.vets.web.VetResourceTest         : Starting VetResourceTest using Java 23 with PID 39200 (started by girachawda in /Users/girachawda/3241/spring-petclinic-microservices/spring-petclinic-vets-service)
2026-07-05T19:42:08.742-04:00  INFO 39200 --- [vets-service] [           main] [                                                 ] o.s.s.p.vets.web.VetResourceTest         : The following 1 profile is active: "test"
2026-07-05T19:42:08.752-04:00  INFO 39200 --- [vets-service] [           main] [                                                 ] o.s.c.c.c.ConfigServerConfigDataLoader   : Fetching config from server at : http://localhost:8888/
2026-07-05T19:42:08.752-04:00  INFO 39200 --- [vets-service] [           main] [                                                 ] o.s.c.c.c.ConfigServerConfigDataLoader   : Exception on Url - http://localhost:8888/:org.springframework.web.client.ResourceAccessException: I/O error on GET request for "http://localhost:8888/vets-service/default": Connection refused. Will be trying the next url if available
2026-07-05T19:42:08.752-04:00  WARN 39200 --- [vets-service] [           main] [                                                 ] o.s.c.c.c.ConfigServerConfigDataLoader   : Could not locate PropertySource ([ConfigServerConfigDataResource@f833223 uris = array<String>['http://localhost:8888/'], optional = true, profiles = 'default']): I/O error on GET request for "http://localhost:8888/vets-service/default": Connection refused
2026-07-05T19:42:08.752-04:00  INFO 39200 --- [vets-service] [           main] [                                                 ] o.s.c.c.c.ConfigServerConfigDataLoader   : Fetching config from server at : http://localhost:8888/
2026-07-05T19:42:08.752-04:00  INFO 39200 --- [vets-service] [           main] [                                                 ] o.s.c.c.c.ConfigServerConfigDataLoader   : Exception on Url - http://localhost:8888/:org.springframework.web.client.ResourceAccessException: I/O error on GET request for "http://localhost:8888/vets-service/test": Connection refused. Will be trying the next url if available
2026-07-05T19:42:08.752-04:00  WARN 39200 --- [vets-service] [           main] [                                                 ] o.s.c.c.c.ConfigServerConfigDataLoader   : Could not locate PropertySource ([ConfigServerConfigDataResource@7dfab58d uris = array<String>['http://localhost:8888/'], optional = true, profiles = 'test']): I/O error on GET request for "http://localhost:8888/vets-service/test": Connection refused
2026-07-05T19:42:08.753-04:00  INFO 39200 --- [vets-service] [           main] [                                                 ] o.s.c.c.c.ConfigServerConfigDataLoader   : Fetching config from server at : http://localhost:8888/
2026-07-05T19:42:08.753-04:00  INFO 39200 --- [vets-service] [           main] [                                                 ] o.s.c.c.c.ConfigServerConfigDataLoader   : Exception on Url - http://localhost:8888/:org.springframework.web.client.ResourceAccessException: I/O error on GET request for "http://localhost:8888/vets-service/default": Connection refused. Will be trying the next url if available
2026-07-05T19:42:08.753-04:00  WARN 39200 --- [vets-service] [           main] [                                                 ] o.s.c.c.c.ConfigServerConfigDataLoader   : Could not locate PropertySource ([ConfigServerConfigDataResource@29d29657 uris = array<String>['http://localhost:8888/'], optional = true, profiles = 'default']): I/O error on GET request for "http://localhost:8888/vets-service/default": Connection refused
Mockito is currently self-attaching to enable the inline-mock-maker. This will no longer work in future releases of the JDK. Please add Mockito as an agent to your build as described in Mockito's documentation: https://javadoc.io/doc/org.mockito/mockito-core/latest/org.mockito/org/mockito/Mockito.html#0.3
Java HotSpot(TM) 64-Bit Server VM warning: Sharing is only supported for boot loader classes because bootstrap classpath has been appended
WARNING: A Java agent has been loaded dynamically (/Users/girachawda/.m2/repository/net/bytebuddy/byte-buddy-agent/1.17.8/byte-buddy-agent-1.17.8.jar)
WARNING: If a serviceability tool is in use, please run with -XX:+EnableDynamicAgentLoading to hide this warning
WARNING: If a serviceability tool is not in use, please run with -Djdk.instrument.traceUsage for more information
WARNING: Dynamic loading of agents will be disallowed by default in a future release
2026-07-05T19:42:09.886-04:00  INFO 39200 --- [vets-service] [           main] [                                                 ] o.s.b.t.m.w.SpringBootMockServletContext : Initializing Spring TestDispatcherServlet ''
2026-07-05T19:42:09.887-04:00  INFO 39200 --- [vets-service] [           main] [                                                 ] o.s.t.web.servlet.TestDispatcherServlet  : Initializing Servlet ''
2026-07-05T19:42:09.888-04:00  INFO 39200 --- [vets-service] [           main] [                                                 ] o.s.t.web.servlet.TestDispatcherServlet  : Completed initialization in 1 ms
2026-07-05T19:42:09.903-04:00  INFO 39200 --- [vets-service] [           main] [                                                 ] o.s.s.p.vets.web.VetResourceTest         : Started VetResourceTest in 1.81 seconds (process running for 2.737)
[INFO] Tests run: 1, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 2.298 s -- in org.springframework.samples.petclinic.vets.web.VetResourceTest
[INFO] 
[INFO] Results:
[INFO] 
[INFO] Tests run: 1, Failures: 0, Errors: 0, Skipped: 0
[INFO] 
[INFO] 
[INFO] --- jacoco:0.8.12:report (jacoco-report) @ spring-petclinic-vets-service ---
[INFO] Loading execution data file /Users/girachawda/3241/spring-petclinic-microservices/spring-petclinic-vets-service/target/jacoco.exec
[INFO] Analyzed bundle 'spring-petclinic-vets-service' with 7 classes
[INFO] 
[INFO] --< org.springframework.samples.petclinic.visits:spring-petclinic-visits-service >--
[INFO] Building spring-petclinic-visits-service 4.0.1                     [4/4]
[INFO]   from /Users/girachawda/3241/spring-petclinic-microservices/spring-petclinic-visits-service/pom.xml
[INFO] --------------------------------[ jar ]---------------------------------
[INFO] 
[INFO] --- enforcer:3.6.2:enforce (enforce-java) @ spring-petclinic-visits-service ---
[INFO] 
[INFO] --- git-commit-id:9.0.2:revision (default) @ spring-petclinic-visits-service ---
[INFO] dotGitDirectory '/Users/girachawda/3241/spring-petclinic-microservices/.git'
[INFO] Collected git.build.user.name with value Gira Chawda
[INFO] Collected git.build.user.email with value girachawda101@gmail.com
[INFO] Collected git.branch with value create-ci-workflow
[INFO] Collected git.commit.id.describe with value dede0df
[INFO] Collected git.commit.id.describe-short with value dede0df
[INFO] Collected git.commit.id with value dede0dfe84c00a1dc5ba5721f14611092293555f
[INFO] Collected git.commit.id.abbrev with value dede0df
[INFO] Collected git.dirty with value false
[INFO] Collected git.commit.user.name with value Gira Chawda
[INFO] Collected git.commit.user.email with value girachawda101@gmail.com
[INFO] Collected git.commit.message.full with value Create CI github workflow
[INFO] Collected git.commit.message.short with value Create CI github workflow
[INFO] Collected git.commit.time with value 2026-07-05T19:28:01-0400
[INFO] Collected git.commit.author.time with value 2026-07-05T19:28:01-0400
[INFO] Collected git.commit.committer.time with value 2026-07-05T19:28:01-0400
[INFO] Collected git.remote.origin.url with value https://github.com/spring-petclinic/spring-petclinic-microservices.git
[INFO] Collected git.tags with value 
[INFO] Collected git.tag with value 
[INFO] Collected git.closest.tag.name with value 
[INFO] Collected git.closest.tag.commit.count with value 
[INFO] Collected git.total.commit.count with value 760
[INFO] Collected git.local.branch.ahead with value 0
[INFO] Collected git.local.branch.behind with value 0
[INFO] Collected git.build.time with value 2026-07-05T19:42:10-0400
[INFO] Collected git.build.version with value 4.0.1
[INFO] Collected git.build.host with value Giras-MacBook-Air.local
[INFO] including property 'git.tags' in results
[INFO] including property 'git.build.version' in results
[INFO] including property 'git.branch' in results
[INFO] including property 'git.build.host' in results
[INFO] including property 'git.commit.id' in results
[INFO] including property 'git.commit.user.email' in results
[INFO] including property 'git.local.branch.behind' in results
[INFO] including property 'git.commit.author.time' in results
[INFO] including property 'git.build.user.name' in results
[INFO] including property 'git.dirty' in results
[INFO] including property 'git.closest.tag.commit.count' in results
[INFO] including property 'git.commit.user.name' in results
[INFO] including property 'git.commit.id.abbrev' in results
[INFO] including property 'git.commit.id.describe-short' in results
[INFO] including property 'git.total.commit.count' in results
[INFO] including property 'git.commit.id.describe' in results
[INFO] including property 'git.build.user.email' in results
[INFO] including property 'git.commit.message.short' in results
[INFO] including property 'git.commit.committer.time' in results
[INFO] including property 'git.tag' in results
[INFO] including property 'git.closest.tag.name' in results
[INFO] including property 'git.local.branch.ahead' in results
[INFO] including property 'git.commit.time' in results
[INFO] including property 'git.build.time' in results
[INFO] including property 'git.commit.message.full' in results
[INFO] including property 'git.remote.origin.url' in results
[INFO] Reading existing properties file [/Users/girachawda/3241/spring-petclinic-microservices/spring-petclinic-visits-service/target/classes/git.properties] (for project spring-petclinic-visits-service)...
[INFO] Writing properties file [/Users/girachawda/3241/spring-petclinic-microservices/spring-petclinic-visits-service/target/classes/git.properties] (for project spring-petclinic-visits-service)...
[INFO] 
[INFO] --- jacoco:0.8.12:prepare-agent (jacoco-prepare-agent) @ spring-petclinic-visits-service ---
[INFO] argLine set to -javaagent:/Users/girachawda/.m2/repository/org/jacoco/org.jacoco.agent/0.8.12/org.jacoco.agent-0.8.12-runtime.jar=destfile=/Users/girachawda/3241/spring-petclinic-microservices/spring-petclinic-visits-service/target/jacoco.exec
[INFO] 
[INFO] --- spring-boot:4.0.1:build-info (default) @ spring-petclinic-visits-service ---
[INFO] 
[INFO] --- resources:3.3.1:resources (default-resources) @ spring-petclinic-visits-service ---
[INFO] Copying 1 resource from src/main/resources to target/classes
[INFO] Copying 5 resources from src/main/resources to target/classes
[INFO] 
[INFO] --- compiler:3.14.1:compile (default-compile) @ spring-petclinic-visits-service ---
[INFO] Nothing to compile - all classes are up to date.
[INFO] 
[INFO] --- resources:3.3.1:testResources (default-testResources) @ spring-petclinic-visits-service ---
[INFO] Copying 1 resource from src/test/resources to target/test-classes
[INFO] 
[INFO] --- compiler:3.14.1:testCompile (default-testCompile) @ spring-petclinic-visits-service ---
[INFO] Nothing to compile - all classes are up to date.
[INFO] 
[INFO] --- surefire:3.5.4:test (default-test) @ spring-petclinic-visits-service ---
[INFO] Using auto detected provider org.apache.maven.surefire.junitplatform.JUnitPlatformProvider
[INFO] 
[INFO] -------------------------------------------------------
[INFO]  T E S T S
[INFO] -------------------------------------------------------
[INFO] Running org.springframework.samples.petclinic.visits.web.VisitResourceTest
19:42:11.090 [main] INFO org.springframework.test.context.support.AnnotationConfigContextLoaderUtils -- Could not detect default configuration classes for test class [org.springframework.samples.petclinic.visits.web.VisitResourceTest]: VisitResourceTest does not declare any static, non-private, non-final, nested classes annotated with @Configuration.
19:42:11.186 [main] INFO org.springframework.boot.test.context.SpringBootTestContextBootstrapper -- Found @SpringBootConfiguration org.springframework.samples.petclinic.visits.VisitsServiceApplication for test class org.springframework.samples.petclinic.visits.web.VisitResourceTest
19:42:11,874 |-WARN in ch.qos.logback.core.model.processor.ImplicitModelHandler - Ignoring unknown property [jmxConfigurator] in [ch.qos.logback.classic.LoggerContext]

  .   ____          _            __ _ _
 /\\ / ___'_ __ _ _(_)_ __  __ _ \ \ \ \
( ( )\___ | '_ | '_| | '_ \/ _` | \ \ \ \
 \\/  ___)| |_)| | | | | || (_| |  ) ) ) )
  '  |____| .__|_| |_|_| |_\__, | / / / /
 =========|_|==============|___/=/_/_/_/

 :: Spring Boot ::                (v4.0.1)

2026-07-05T19:42:11.974-04:00  INFO 39203 --- [visits-service] [           main] [                                                 ] o.s.s.p.visits.web.VisitResourceTest     : Starting VisitResourceTest using Java 23 with PID 39203 (started by girachawda in /Users/girachawda/3241/spring-petclinic-microservices/spring-petclinic-visits-service)
2026-07-05T19:42:11.976-04:00  INFO 39203 --- [visits-service] [           main] [                                                 ] o.s.s.p.visits.web.VisitResourceTest     : The following 1 profile is active: "test"
2026-07-05T19:42:11.984-04:00  INFO 39203 --- [visits-service] [           main] [                                                 ] o.s.c.c.c.ConfigServerConfigDataLoader   : Fetching config from server at : http://localhost:8888/
2026-07-05T19:42:11.984-04:00  INFO 39203 --- [visits-service] [           main] [                                                 ] o.s.c.c.c.ConfigServerConfigDataLoader   : Exception on Url - http://localhost:8888/:org.springframework.web.client.ResourceAccessException: I/O error on GET request for "http://localhost:8888/visits-service/default": Connection refused. Will be trying the next url if available
2026-07-05T19:42:11.984-04:00  WARN 39203 --- [visits-service] [           main] [                                                 ] o.s.c.c.c.ConfigServerConfigDataLoader   : Could not locate PropertySource ([ConfigServerConfigDataResource@1a7437d8 uris = array<String>['http://localhost:8888/'], optional = true, profiles = 'default']): I/O error on GET request for "http://localhost:8888/visits-service/default": Connection refused
2026-07-05T19:42:11.985-04:00  INFO 39203 --- [visits-service] [           main] [                                                 ] o.s.c.c.c.ConfigServerConfigDataLoader   : Fetching config from server at : http://localhost:8888/
2026-07-05T19:42:11.985-04:00  INFO 39203 --- [visits-service] [           main] [                                                 ] o.s.c.c.c.ConfigServerConfigDataLoader   : Exception on Url - http://localhost:8888/:org.springframework.web.client.ResourceAccessException: I/O error on GET request for "http://localhost:8888/visits-service/test": Connection refused. Will be trying the next url if available
2026-07-05T19:42:11.985-04:00  WARN 39203 --- [visits-service] [           main] [                                                 ] o.s.c.c.c.ConfigServerConfigDataLoader   : Could not locate PropertySource ([ConfigServerConfigDataResource@745c8a04 uris = array<String>['http://localhost:8888/'], optional = true, profiles = 'test']): I/O error on GET request for "http://localhost:8888/visits-service/test": Connection refused
2026-07-05T19:42:11.985-04:00  INFO 39203 --- [visits-service] [           main] [                                                 ] o.s.c.c.c.ConfigServerConfigDataLoader   : Fetching config from server at : http://localhost:8888/
2026-07-05T19:42:11.985-04:00  INFO 39203 --- [visits-service] [           main] [                                                 ] o.s.c.c.c.ConfigServerConfigDataLoader   : Exception on Url - http://localhost:8888/:org.springframework.web.client.ResourceAccessException: I/O error on GET request for "http://localhost:8888/visits-service/default": Connection refused. Will be trying the next url if available
2026-07-05T19:42:11.985-04:00  WARN 39203 --- [visits-service] [           main] [                                                 ] o.s.c.c.c.ConfigServerConfigDataLoader   : Could not locate PropertySource ([ConfigServerConfigDataResource@59d29065 uris = array<String>['http://localhost:8888/'], optional = true, profiles = 'default']): I/O error on GET request for "http://localhost:8888/visits-service/default": Connection refused
Mockito is currently self-attaching to enable the inline-mock-maker. This will no longer work in future releases of the JDK. Please add Mockito as an agent to your build as described in Mockito's documentation: https://javadoc.io/doc/org.mockito/mockito-core/latest/org.mockito/org/mockito/Mockito.html#0.3
Java HotSpot(TM) 64-Bit Server VM warning: Sharing is only supported for boot loader classes because bootstrap classpath has been appended
WARNING: A Java agent has been loaded dynamically (/Users/girachawda/.m2/repository/net/bytebuddy/byte-buddy-agent/1.17.8/byte-buddy-agent-1.17.8.jar)
WARNING: If a serviceability tool is in use, please run with -XX:+EnableDynamicAgentLoading to hide this warning
WARNING: If a serviceability tool is not in use, please run with -Djdk.instrument.traceUsage for more information
WARNING: Dynamic loading of agents will be disallowed by default in a future release
2026-07-05T19:42:13.140-04:00  INFO 39203 --- [visits-service] [           main] [                                                 ] o.s.b.t.m.w.SpringBootMockServletContext : Initializing Spring TestDispatcherServlet ''
2026-07-05T19:42:13.143-04:00  INFO 39203 --- [visits-service] [           main] [                                                 ] o.s.t.web.servlet.TestDispatcherServlet  : Initializing Servlet ''
2026-07-05T19:42:13.144-04:00  INFO 39203 --- [visits-service] [           main] [                                                 ] o.s.t.web.servlet.TestDispatcherServlet  : Completed initialization in 1 ms
2026-07-05T19:42:13.164-04:00  INFO 39203 --- [visits-service] [           main] [                                                 ] o.s.s.p.visits.web.VisitResourceTest     : Started VisitResourceTest in 1.803 seconds (process running for 2.827)
2026-07-05T19:42:13.201-04:00  WARN 39203 --- [visits-service] [           main] [                                                 ] .w.s.m.s.DefaultHandlerExceptionResolver : Resolved [org.springframework.http.converter.HttpMessageNotReadableException: Required request body is missing: public org.springframework.samples.petclinic.visits.model.Visit org.springframework.samples.petclinic.visits.web.VisitResource.create(org.springframework.samples.petclinic.visits.model.Visit,int)]
[INFO] Tests run: 2, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 2.332 s -- in org.springframework.samples.petclinic.visits.web.VisitResourceTest
[INFO] 
[INFO] Results:
[INFO] 
[INFO] Tests run: 2, Failures: 0, Errors: 0, Skipped: 0
[INFO] 
[INFO] 
[INFO] --- jacoco:0.8.12:report (jacoco-report) @ spring-petclinic-visits-service ---
[INFO] Loading execution data file /Users/girachawda/3241/spring-petclinic-microservices/spring-petclinic-visits-service/target/jacoco.exec
[INFO] Analyzed bundle 'spring-petclinic-visits-service' with 6 classes
[INFO] ------------------------------------------------------------------------
[INFO] Reactor Summary for spring-petclinic-admin-server 4.0.1:
[INFO] 
[INFO] spring-petclinic-admin-server ...................... SUCCESS [  6.977 s]
[INFO] spring-petclinic-customers-service ................. SUCCESS [  3.713 s]
[INFO] spring-petclinic-vets-service ...................... SUCCESS [  3.182 s]
[INFO] spring-petclinic-visits-service .................... SUCCESS [  3.279 s]
[INFO] ------------------------------------------------------------------------
[INFO] BUILD SUCCESS
[INFO] ------------------------------------------------------------------------
[INFO] Total time:  17.334 s
[INFO] Finished at: 2026-07-05T19:42:13-04:00
[INFO] ------------------------------------------------------------------------
```