### PR TITLE
fix(workflows): avoid require('@actions/github') in triage-pr script

### DIFF
--- a/.github/workflows/check-pr-template.yml
+++ b/.github/workflows/check-pr-template.yml
@@ -57,20 +57,24 @@ jobs:
             // using GITHUB_TOKEN — it cannot distinguish members from non-members.
             //
             // Solution: use ORG_READ_PAT (a classic PAT with read:org scope stored as a
-            // repo/org secret) only for this call. All write operations below still use
-            // the default GITHUB_TOKEN so automated comments appear as github-actions[bot].
+            // repo/org secret) only for this call, by overriding the Authorization header
+            // on a single request through the existing `github` client. All write
+            // operations below still use the default GITHUB_TOKEN so automated comments
+            // appear as github-actions[bot].
+            //
+            // Note: `require('@actions/github')` is NOT available here — github-script's
+            // bundled runtime has no on-disk node_modules for user scripts to resolve
+            // against, so requiring it throws "Cannot find module '@actions/github'".
             //
             // Fallback: if ORG_READ_PAT is not configured, the GITHUB_TOKEN is used and
             // only *public* org members are bypassed (302 is treated as non-member).
             const orgReadToken = process.env.ORG_READ_PAT;
-            const orgClient = orgReadToken
-              ? require('@actions/github').getOctokit(orgReadToken)
-              : github;
 
             try {
-              const { status } = await orgClient.rest.orgs.checkMembershipForUser({
+              const { status } = await github.request('GET /orgs/{org}/members/{username}', {
                 org: context.repo.owner,
                 username: pr.user.login,
+                headers: orgReadToken ? { authorization: `token ${orgReadToken}` } : undefined,
               });
               if (status === 204) {
                 console.log(`@${pr.user.login} is a ${context.repo.owner} org member — skipping triage.`);


### PR DESCRIPTION
## Summary

Fixes the `triage-pr` check that has been failing on every PR (e.g. #555) since #543 was merged.

- `require('@actions/github')` inside the `actions/github-script@v7` script throws `Error: Cannot find module '@actions/github'` — github-script bundles its runtime with `ncc`, so there's no on-disk `node_modules` for user scripts to `require()` external packages against.
- This made the org-member bypass step fail on every PR, regardless of author or content.

## Fix

Instead of constructing a second Octokit client with `ORG_READ_PAT`, reuse the already-injected `github` client and override just the `Authorization` header on the single `checkMembershipForUser` request via `github.request()`, which Octokit supports natively for per-call auth overrides. All other calls in the script keep using the default `GITHUB_TOKEN`, preserving the original dual-token behavior described in the code comments.

## Testing

- Validated the workflow YAML parses correctly.
- Read through the `github.request()` per-call header override behavior in Octokit — it takes precedence over the client's default `Authorization` header for that single request only.

Fixes #555's `triage-pr` failure (indirectly — that check re-runs against `main`'s workflow once this merges).
