### PR TITLE
Validate pet birthday

### DIFF
--- a/spring-petclinic-customers-service/src/main/java/org/springframework/samples/petclinic/customers/web/PetRequest.java
+++ b/spring-petclinic-customers-service/src/main/java/org/springframework/samples/petclinic/customers/web/PetRequest.java
@@ -17,6 +17,7 @@ package org.springframework.samples.petclinic.customers.web;
 
 import com.fasterxml.jackson.annotation.JsonFormat;
 import jakarta.validation.constraints.Size;
+import jakarta.validation.constraints.PastOrPresent;
 
 import java.util.Date;
 
@@ -25,7 +26,7 @@ import java.util.Date;
  */
 record PetRequest(int id,
                   @JsonFormat(pattern = "yyyy-MM-dd")
-                  Date birthDate,
+                  @PastOrPresent Date birthDate,
                   @Size(min = 1)
                   String name,
                   int typeId

--- a/spring-petclinic-customers-service/src/main/java/org/springframework/samples/petclinic/customers/web/PetResource.java
+++ b/spring-petclinic-customers-service/src/main/java/org/springframework/samples/petclinic/customers/web/PetResource.java
@@ -55,7 +55,7 @@ class PetResource {
     @PostMapping("/owners/{ownerId}/pets")
     @ResponseStatus(HttpStatus.CREATED)
     public Pet processCreationForm(
-        @RequestBody PetRequest petRequest,
+        @RequestBody @Valid PetRequest petRequest,
         @PathVariable("ownerId") @Min(1) int ownerId) {
 
         Owner owner = ownerRepository.findById(ownerId)

--- a/spring-petclinic-customers-service/src/main/java/org/springframework/samples/petclinic/customers/web/PetResource.java
+++ b/spring-petclinic-customers-service/src/main/java/org/springframework/samples/petclinic/customers/web/PetResource.java
@@ -16,6 +16,7 @@
 package org.springframework.samples.petclinic.customers.web;
 
 import io.micrometer.core.annotation.Timed;
+import jakarta.validation.Valid;
 import jakarta.validation.constraints.Min;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -67,7 +68,7 @@ class PetResource {
 
     @PutMapping("/owners/*/pets/{petId}")
     @ResponseStatus(HttpStatus.NO_CONTENT)
-    public void processUpdateForm(@RequestBody PetRequest petRequest) {
+    public void processUpdateForm(@Valid @RequestBody PetRequest petRequest) {
         int petId = petRequest.id();
         Pet pet = findPetById(petId);
         save(pet, petRequest);

--- a/spring-petclinic-customers-service/src/test/java/org/springframework/samples/petclinic/customers/web/PetResourceTest.java
+++ b/spring-petclinic-customers-service/src/test/java/org/springframework/samples/petclinic/customers/web/PetResourceTest.java
@@ -14,10 +14,12 @@ import org.springframework.samples.petclinic.customers.model.PetType;
 import org.springframework.test.context.ActiveProfiles;
 import org.springframework.test.context.bean.override.mockito.MockitoBean;
 import org.springframework.test.web.servlet.MockMvc;
+import org.springframework.test.web.servlet.request.MockMvcRequestBuilders;
 
 
 import static org.mockito.BDDMockito.given;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.put;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.content;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
@@ -53,13 +55,37 @@ class PetResourceTest {
             .andExpect(jsonPath("$.name").value("Basil"))
             .andExpect(jsonPath("$.type.id").value(6));
     }
-    
+
     @Test
     void shouldReturnNotFoundWhenPetDoesNotExist() throws Exception {
         given(petRepository.findById(99)).willReturn(Optional.empty());
 
         mvc.perform(get("/owners/2/pets/99").accept(MediaType.APPLICATION_JSON))
             .andExpect(status().isNotFound());
+    }
+
+    @Test
+    void shouldRejectFuturePetBirthdayOnUpdate() throws Exception{
+        String futureBirthDateJson = """
+        {"id": 2, "name": "Basil", "typeId": 6, "birthDate": "2030-01-01"}
+        """;
+
+        mvc.perform(put("/owners/2/pets/2")
+            .contentType(MediaType.APPLICATION_JSON)
+            .content(futureBirthDateJson))
+            .andExpect(status().isBadRequest());
+    }
+
+    @Test
+    void shouldRejectFuturePetBirthdayOnPost() throws Exception{
+        String futureBirthDateJson = """
+        {"id": 2, "name": "Basil", "typeId": 6, "birthDate": "2030-01-01"}
+        """;
+
+        mvc.perform(MockMvcRequestBuilders.post("/owners/2/pets")
+                .contentType(MediaType.APPLICATION_JSON)
+                .content(futureBirthDateJson))
+            .andExpect(status().isBadRequest());
     }
 
     private Pet setupPet() {

--- a/spring-petclinic-customers-service/src/test/java/org/springframework/samples/petclinic/customers/web/PetResourceTest.java
+++ b/spring-petclinic-customers-service/src/test/java/org/springframework/samples/petclinic/customers/web/PetResourceTest.java
@@ -1,5 +1,6 @@
 package org.springframework.samples.petclinic.customers.web;
 
+import java.time.LocalDate;
 import java.util.Optional;
 
 import org.junit.jupiter.api.Test;
@@ -14,8 +15,6 @@ import org.springframework.samples.petclinic.customers.model.PetType;
 import org.springframework.test.context.ActiveProfiles;
 import org.springframework.test.context.bean.override.mockito.MockitoBean;
 import org.springframework.test.web.servlet.MockMvc;
-import org.springframework.test.web.servlet.request.MockMvcRequestBuilders;
-
 
 import static org.mockito.BDDMockito.given;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
@@ -23,6 +22,7 @@ import static org.springframework.test.web.servlet.request.MockMvcRequestBuilder
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.content;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
 
 /**
  * @author Maciej Szarlinski
@@ -66,9 +66,10 @@ class PetResourceTest {
 
     @Test
     void shouldRejectFuturePetBirthdayOnUpdate() throws Exception{
+        String futureDate = LocalDate.now().plusYears(1).toString();
         String futureBirthDateJson = """
-        {"id": 2, "name": "Basil", "typeId": 6, "birthDate": "2030-01-01"}
-        """;
+        {"id": 2, "name": "Basil", "typeId": 6, "birthDate": "%s"}
+        """.formatted(futureDate);
 
         mvc.perform(put("/owners/2/pets/2")
             .contentType(MediaType.APPLICATION_JSON)
@@ -78,11 +79,12 @@ class PetResourceTest {
 
     @Test
     void shouldRejectFuturePetBirthdayOnPost() throws Exception{
+        String futureDate = LocalDate.now().plusYears(1).toString();
         String futureBirthDateJson = """
-        {"id": 2, "name": "Basil", "typeId": 6, "birthDate": "2030-01-01"}
-        """;
+        {"name": "Basil", "typeId": 6, "birthDate": "%s"}
+        """.formatted(futureDate);
 
-        mvc.perform(MockMvcRequestBuilders.post("/owners/2/pets")
+        mvc.perform(post("/owners/2/pets")
                 .contentType(MediaType.APPLICATION_JSON)
                 .content(futureBirthDateJson))
             .andExpect(status().isBadRequest());


### PR DESCRIPTION
## Description

-Add validation to reject future pet birth dates

-Adds '@PastOrPresent' validation to PetRequest.birthDate to prevent pets from being registered with a birth date in the future.

Fixes #558 

While testing, I found processUpdateForm (PUT /owners/{ownerId}/pets/{petId}) was missing '@Valid' on its PetRequest parameter, meaning validation constraints - including the pre-existing '@Size' on name - were never actually being enforced on updates. Added '@Valid' there as well.

Testing: Added unit tests covering both the create (POST) and update (PUT) endpoints, confirming future birth dates are rejected with 400.

Note: While testing manually, I also noticed the frontend doesn't surface a validation error to the user when submission fails filed as a separate issue: Issue #557 (Status: Open)

## Type of change

- Bug fix

## Checklist

- [x] I have read the [CONTRIBUTING](../CONTRIBUTING.md) guide
- [x] **This is NOT coursework, a student assignment, or homework** — I understand that forks of this repo are widely used in courses and that student PRs will be closed without review
- [x] My change targets the `main` branch of **spring-petclinic/spring-petclinic-microservices**, not my own fork
- [x] I have tested this change locally
- [x] Existing tests pass (`./mvnw test`)

> ⚠️ **Are you a student?**  
> If you forked this repo for a course or bootcamp, your changes belong in **your own fork**, not here.  x
> PRs that are part of a course assignment will be labelled `invalid` and closed immediately. x
